### PR TITLE
refactor: create contrib directory

### DIFF
--- a/Contrib/Auth/Did/Did.csproj
+++ b/Contrib/Auth/Did/Did.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/Contrib/Auth/Did/DidAuth.cs
+++ b/Contrib/Auth/Did/DidAuth.cs
@@ -1,0 +1,5 @@
+namespace Basis.Contrib.Auth.Did
+{
+	// TODO: Create and implement an `IChallengeResponseAuth` interface. This interface should live in basis core.
+	public class DidAuthentication { }
+}

--- a/Contrib/Auth/Did/README.md
+++ b/Contrib/Auth/Did/README.md
@@ -1,0 +1,4 @@
+# DID Authentication
+
+Serves as the home for authentication based on Decentralized Identifiers
+(DIDs).

--- a/Contrib/Auth/README.md
+++ b/Contrib/Auth/README.md
@@ -1,0 +1,3 @@
+# Authentication
+
+This directory houses all third-party authentication integrations.

--- a/Contrib/README.md
+++ b/Contrib/README.md
@@ -1,0 +1,41 @@
+# Basis Third-Party Contributions
+
+This directory is for community contributions to Basis which are incubating,
+insufficiently generic, or may have a practical reason to avoid direct
+inclusion in the core project. For (non-exhaustive) examples of code that
+should go in `contrib`:
+
+* Integrations with third party cloud APIs/services.
+* Code that is "insufficiently generic" or tailored to use cases that are too
+  specific to be useful for all Basis-derived projects.
+* Code that has not yet been agreed upon for general inclusion in all
+  Basis-derived projects.
+
+## Directory and Project Structure
+
+Contributions are grouped into "categories", which are directories like
+`contrib/auth` for authentication integrations, or `contrib/assets` for asset
+related integrations.
+
+Beneath each category are a list of directories, one directory per distinct
+contribution. Each one will be one or more C# class libraries, with their own
+`.csproj` files. This will allow applications that wish to use the code to depend
+on it via MSBuild using either the [`<ProjectReference>`][ProjectReference]
+property or other means.
+
+## Disclaimers
+
+* Projects in `contrib`, or `contrib` itself, may be relocated in the future,
+  either incorporated into the core project or moved into an external repository,
+  or both in parts.
+* Although prior discussion is ideal, this may happen without much prior notice.
+* Code in `contrib` should be considered "unsupported" API, for the purposes of
+  API breakage.
+* Incorporation of `contrib` libraries into the Basis Demo does not imply
+  intent to merge into the core project.
+* Alignment with the core project is not necessarily a requirement for
+  inclusion into contrib.
+* Contributors are encouraged to seek modular solutions that can be hosted in
+  external repositories, when possible.
+
+[ProjectReference]: https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-items?view=vs-2022#projectreference


### PR DESCRIPTION
~Rebased on #81~

Introduces a directory to hold code that isn't part of the core framework.