### PR TITLE
Fix audio occlusion and reflections

### DIFF
--- a/Basis/Packages/com.basis.framework/Drivers/BasisLocalCameraDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/BasisLocalCameraDriver.cs
@@ -3,12 +3,14 @@ using Basis.Scripts.BasisSdk.Players;
 using Basis.Scripts.Device_Management;
 using Basis.Scripts.TransformBinders;
 using System.Collections;
+using SteamAudio;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
 using UnityEngine.UI;
 using UnityEngine.UIElements;
 using UnityEngine.XR;
+using Vector3 = UnityEngine.Vector3;
 
 namespace Basis.Scripts.Drivers
 {
@@ -81,6 +83,11 @@ namespace Basis.Scripts.Drivers
             // Target scale for the "bounce" effect (e.g., 1.2 times larger)
             largerScale = StartingScale * 1.2f;
             UpdateMicrophoneVisuals(MicrophoneRecorder.isPaused, false);
+
+            if (SteamAudioListener != null)
+            {
+                SteamAudioManager.NotifyAudioListenerChanged();
+            }
         }
         public void MicrophoneTransmitting()
         {


### PR DESCRIPTION
Audio occlusion and reflections with steam audio sources are not working. 

[Without occlusion and reflections.webm](https://github.com/user-attachments/assets/eec6d519-9c91-4de8-bc4b-65bf559d2403)

I found [this comment](https://github.com/ValveSoftware/steam-audio/issues/295#issuecomment-1873505547) saying that a listener that gets added at runtime is not automatically picked up by steam audio. And the listener in basis sits on a prefab that is spawned at runtime. 

Calling `SteamAudioManager.NotifyAudioListenerChanged();` after the listener is spawned fixes reflections and occlusions. I added it to the `BasisLocalCameraDriver` because its on the prefab with the listener. 

[With occlusion and reflections.webm](https://github.com/user-attachments/assets/f03dfc07-0580-49c3-9ee4-2ee2e40015f8)

