### PR TITLE
Drop unused meta files

### DIFF
--- a/Basis/Packages/com.basis.server/BasisNetworkClient/BasisNetworkClient.csproj.meta
+++ b/Basis/Packages/com.basis.server/BasisNetworkClient/BasisNetworkClient.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 4d8b346f6a8143b48b2443ff6b35601e
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Basis/Packages/com.basis.server/BasisNetworkClientConsole/BasisNetworkClientConsole/BasisNetworkClientConsole.csproj.meta
+++ b/Basis/Packages/com.basis.server/BasisNetworkClientConsole/BasisNetworkClientConsole/BasisNetworkClientConsole.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: ae9b52b3a73ff734aa39b00d1c5f6acd
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkCore.csproj.meta
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkCore.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: f496fb651123d3e47a0777f3d5c7203e
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Basis/Packages/com.basis.server/BasisNetworkServer.sln.meta
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer.sln.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: b4b21fd4b5fb8244bb29e3ebff475bd6
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkServer.csproj.meta
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkServer.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 9db52faad6569b241897bafb3e74a8bd
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Basis/Packages/com.basis.server/BasisPrometheus/BasisPrometheus.csproj.meta
+++ b/Basis/Packages/com.basis.server/BasisPrometheus/BasisPrometheus.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 38cb6f5b87b8ea74db62f515177b7624
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Basis/Packages/com.basis.server/BasisServerConsole/BasisNetworkConsole.csproj.meta
+++ b/Basis/Packages/com.basis.server/BasisServerConsole/BasisNetworkConsole.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: a70a4581412f9ea43a9bfb9b1b0e3afc
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Basis/Packages/com.basis.server/LiteNetLib/LiteNetLib.csproj.meta
+++ b/Basis/Packages/com.basis.server/LiteNetLib/LiteNetLib.csproj.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: bb64744ed96b3b145b3c2057ad5e16c7
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
These .meta files are automatically deleted by Unity because the .csproj and .sln files they relate to do not exist in the repo. Delete them to unclutter git on a clean clone. 