### PR TITLE
Stop XR Asset Manangement hanging up the editor for half a minute on project open.

### DIFF
--- a/Basis/ProjectSettings/XRPackageSettings.asset
+++ b/Basis/ProjectSettings/XRPackageSettings.asset
@@ -1,5 +1,6 @@
 {
     "m_Settings": [
+        "ShouldQueryLegacyPackageRemoval",
         "RemoveLegacyInputHelpersForReload"
     ]
 }


### PR DESCRIPTION
Fix Unity bug. Stop XR Management from going into a back-and-forth loop on project open.