### PR TITLE
Pickup runtime loading

### DIFF
--- a/Basis/Packages/com.basis.framework/Players/BasisLocalPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Players/BasisLocalPlayer.cs
@@ -16,6 +16,7 @@ namespace Basis.Scripts.BasisSdk.Players
     public class BasisLocalPlayer : BasisPlayer
     {
         public static BasisLocalPlayer Instance;
+        public static bool PlayerReady = false;
         public static Action OnLocalPlayerCreatedAndReady;
         public static Action OnLocalPlayerCreated;
         public BasisCharacterController.BasisCharacterController Move;
@@ -84,6 +85,7 @@ namespace Basis.Scripts.BasisSdk.Players
                 MicrophoneRecorder = BasisHelpers.GetOrAddComponent<MicrophoneRecorder>(this.gameObject);
             }
             MicrophoneRecorder.TryInitialize();
+            PlayerReady = true;
             OnLocalPlayerCreatedAndReady?.Invoke();
             BasisSceneFactory BasisSceneFactory = FindFirstObjectByType<BasisSceneFactory>(FindObjectsInactive.Exclude);
             if (BasisSceneFactory != null)

--- a/Basis/Packages/com.basis.framework/UI/BasisPointRaycaster.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisPointRaycaster.cs
@@ -24,11 +24,17 @@ namespace Basis.Scripts.UI
         public Ray ray { get; private set; }
         public RaycastHit[] PhysicHits { get; private set; }
         public int PhysicHitCount { get; private set; }
-        const int k_MaxPhysicHitCount = 8;
+        // NOTE: this needs to be >= max number of colliders it can potentiall hit a scene, otherwise it will behave oddly
+        public static int k_MaxPhysicHitCount = 128;
 
 
         public BasisDeviceMatchSettings BasisDeviceMatchableNames;
         public BasisInput BasisInput;
+
+        [Header("Debug")]
+        public bool EnableDebug = false;
+        public List<GameObject> _DebugHitObjects;
+
 
         public override Camera eventCamera => BasisLocalCameraDriver.Instance.Camera;
         const string k_PlayerLayer = "Player";
@@ -89,6 +95,8 @@ namespace Basis.Scripts.UI
             PhysicHitCount = Physics.RaycastNonAlloc(ray, PhysicHits, MaxDistance, Mask, TriggerInteraction);
             // order from raycast is undefined, sort by distance
             Array.Sort(PhysicHits, (a, b) => a.distance.CompareTo(b.distance));
+            if (EnableDebug)
+                UpdateDebug();
         }
 
         // get a span of valid hits sorted by distance
@@ -149,7 +157,10 @@ namespace Basis.Scripts.UI
             
             return false;
         }
-
+        private void UpdateDebug()
+        {
+            _DebugHitObjects = PhysicHits[..PhysicHitCount].Select(x => x.collider != null ? x.collider.gameObject : null).ToList();
+        }
 
 
         public override void Raycast(PointerEventData eventData, List<RaycastResult> resultAppendList)

--- a/Basis/Packages/com.basis.tests/BasisObjectSyncNetworking.cs
+++ b/Basis/Packages/com.basis.tests/BasisObjectSyncNetworking.cs
@@ -21,7 +21,6 @@ public class BasisObjectSyncNetworking : MonoBehaviour
     public BasisPositionRotationScale Next = new BasisPositionRotationScale();
 
     public float LerpMultiplier = 3f;
-    public Rigidbody Rigidbody;
     public BasisContentBase ContentConnector;
     public InteractableObject InteractableObjects;
     public DeliveryMethod DeliveryMethod = DeliveryMethod.Sequenced;
@@ -29,9 +28,6 @@ public class BasisObjectSyncNetworking : MonoBehaviour
     public void Awake()
     {
         if (ContentConnector == null && TryGetComponent<BasisContentBase>(out ContentConnector))
-        {
-        }
-        if (Rigidbody == null && TryGetComponent<Rigidbody>(out Rigidbody))
         {
         }
         if (ContentConnector != null)
@@ -115,18 +111,20 @@ public class BasisObjectSyncNetworking : MonoBehaviour
             IsLocalOwner = IsOwner;
             CurrentOwner = NetIdNewOwner;
             HasActiveOwnership = true;
-            if (Rigidbody != null)
+            // if (Rigidbody != null && !IsLocalOwner)
+            // {
+            //     // TODO: have an initial state for this to reference since we cant always handle
+            //     //       ownership changes properly if state is lost somewhere
+            //     Rigidbody.isKinematic = true;
+            // }
+            if (!IsLocalOwner)
             {
-                Rigidbody.isKinematic = !IsLocalOwner;
-            }
-            if (IsLocalOwner == false)
-            {
-                //   StartRemoteControl();
+                StartRemoteControl();
                 //      BasisObjectSyncSystem.StartApplyRemoteData(this);
             }
             else
             {
-             StopRemoteControl();
+                StopRemoteControl();
                 //   BasisObjectSyncSystem.StopApplyRemoteData(this);
             }
             OwnedPickupSet();

--- a/Basis/Packages/com.basis.tests/Interactable/BasisInputWrapper.cs
+++ b/Basis/Packages/com.basis.tests/Interactable/BasisInputWrapper.cs
@@ -1,10 +1,13 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using Basis.Scripts.BasisSdk.Players;
 using Basis.Scripts.Device_Management.Devices;
 using Basis.Scripts.TransformBinders.BoneControl;
+using UnityEngine;
 
 public abstract partial class InteractableObject
 {
+    [Serializable]
     public enum InteractInputState
     {
         /// <summary>
@@ -25,6 +28,7 @@ public abstract partial class InteractableObject
         Interacting,
     }
     
+    [Serializable]
     public struct BasisInputWrapper
     {
         /// <summary>
@@ -53,12 +57,14 @@ public abstract partial class InteractableObject
             return false;
         }
 
-        public BasisInput Source { get; set; }
+        public BasisInput Source;
 
         public BasisBoneControl BoneControl { get; set; }
         public BasisBoneTrackedRole Role { get; set; }
 
-        private InteractInputState State { get; set; }
+        [SerializeField]
+        // TODO: this should not be editable in editor, useful for debugging for now tho
+        private InteractInputState State;
 
         public InteractInputState GetState()
         {

--- a/Basis/Packages/com.basis.tests/Interactable/InputSources.cs
+++ b/Basis/Packages/com.basis.tests/Interactable/InputSources.cs
@@ -5,6 +5,7 @@ using Basis.Scripts.TransformBinders.BoneControl;
 
 public abstract partial class InteractableObject
 {
+    [Serializable]
     public struct InputSources {
         public BasisInputWrapper desktopCenterEye, leftHand, rightHand;
 

--- a/Basis/Packages/com.basis.tests/Interactable/PickupInteractable.cs
+++ b/Basis/Packages/com.basis.tests/Interactable/PickupInteractable.cs
@@ -374,6 +374,19 @@ public class PickupInteractable : InteractableObject
             return null;   
     }
 
+    public override void StartRemoteControl()
+    {
+        IsPuppeted = true;
+        // _previousKinematicValue = RigidRef.isKinematic;
+        // RigidRef.isKinematic = true;
+        // TODO: _previousKinematic state should be synced so late joiners have pickups behave properly
+    }
+    public override void StopRemoteControl()
+    {
+        IsPuppeted = false;
+        // RigidRef.isKinematic = _previousKinematicValue;
+    }
+
     public override void OnDestroy()
     {
         Destroy(HighlightClone);


### PR DESCRIPTION
- dont mess with rigidbody in object sync, it is the interactable's responsibility to manage itself
- Debug toggle for raycast
- setup inputs on runtime load of object, not just the first local player ready event

fixes #132 