### PR TITLE
feat(did): remove dependency on Microsoft.IdentityModel.Tokens

### DIFF
--- a/Contrib/Auth/Did.Tests/Base64UrlSafeTests.cs
+++ b/Contrib/Auth/Did.Tests/Base64UrlSafeTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace Basis.Contrib.Auth.DecentralizedIds
+{
+	public class Base64UrlSafeTests
+	{
+		[Fact]
+		public void TestEncode()
+		{
+			byte[] bytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
+			string base64 = "3q2-7w";
+
+			Debug.Assert(
+				Base64UrlSafe.Encode(bytes).Equals(base64),
+				"base64 encoding did not match expected value"
+			);
+		}
+
+		[Fact]
+		public void TestDecode()
+		{
+			byte[] bytes = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF };
+			string base64 = "3q2-7w";
+
+			Debug.Assert(
+				Base64UrlSafe.Decode(base64).SequenceEqual(bytes),
+				"base64 decoding was did not match expected value"
+			);
+		}
+	}
+}

--- a/Contrib/Auth/Did.Tests/DidKeyTests.cs
+++ b/Contrib/Auth/Did.Tests/DidKeyTests.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Basis.Contrib.Auth.DecentralizedIds.Newtypes;
 using Xunit;
-using JsonWebKey = Microsoft.IdentityModel.Tokens.JsonWebKey;
 
 namespace Basis.Contrib.Auth.DecentralizedIds
 {

--- a/Contrib/Auth/Did/Base64UrlSafe.cs
+++ b/Contrib/Auth/Did/Base64UrlSafe.cs
@@ -1,0 +1,40 @@
+// Yes, this whole approach is cursed and inefficient. YOLOSWAG.
+
+namespace Basis.Contrib.Auth.DecentralizedIds
+{
+	/// Base64 url-safe encode and decode.
+	public class Base64UrlSafe
+	{
+		public static string Encode(byte[] bytes)
+		{
+			string base64 = System.Convert.ToBase64String(bytes);
+			return base64
+				.TrimEnd('=') // Remove padding
+				.Replace('+', '-') // Convert + to -
+				.Replace('/', '_'); // Convert / to _
+		}
+
+		public static byte[] Decode(string str)
+		{
+			string base64 = str.Replace('-', '+') // Restore + from -
+				.Replace('_', '/'); // Restore / from _
+
+			// Add padding if needed
+			switch (base64.Length % 4)
+			{
+				case 0:
+					break; // No padding needed
+				case 2:
+					base64 += "==";
+					break;
+				case 3:
+					base64 += "=";
+					break;
+				default:
+					throw new System.FormatException("Invalid base64url string length");
+			}
+
+			return System.Convert.FromBase64String(base64);
+		}
+	}
+}

--- a/Contrib/Auth/Did/Did.csproj
+++ b/Contrib/Auth/Did/Did.csproj
@@ -14,9 +14,9 @@
 
   <!--Third-party dependencies-->
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.3.0" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.5.0" />
     <PackageReference Include="SimpleBase" Version="4.0.2" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
     <PackageReference Include="VarInt" Version="1.2.2" />
   </ItemGroup>
 </Project>

--- a/Contrib/Auth/Did/DidDocument.cs
+++ b/Contrib/Auth/Did/DidDocument.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using DidUrlFragment = Basis.Contrib.Auth.DecentralizedIds.Newtypes.DidUrlFragment;
-using JsonWebKey = Microsoft.IdentityModel.Tokens.JsonWebKey;
 
 namespace Basis.Contrib.Auth.DecentralizedIds
 {

--- a/Contrib/Auth/Did/DidKeyResolver.cs
+++ b/Contrib/Auth/Did/DidKeyResolver.cs
@@ -3,14 +3,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Microsoft.IdentityModel.Tokens;
 using Base128 = WojciechMikołajewicz.Base128;
 using Base58 = SimpleBase.Base58;
 using Debug = System.Diagnostics.Debug;
 using Did = Basis.Contrib.Auth.DecentralizedIds.Newtypes.Did;
 using DidUrlFragment = Basis.Contrib.Auth.DecentralizedIds.Newtypes.DidUrlFragment;
 using Ed25519 = Org.BouncyCastle.Math.EC.Rfc8032.Ed25519;
-using JsonWebKey = Microsoft.IdentityModel.Tokens.JsonWebKey;
 using StringSplitOptions = System.StringSplitOptions;
 
 namespace Basis.Contrib.Auth.DecentralizedIds
@@ -91,7 +89,7 @@ namespace Basis.Contrib.Auth.DecentralizedIds
 			{
 				Kty = "OKP",
 				Crv = "Ed25519",
-				X = Base64UrlEncoder.Encode(pubkeyBytes),
+				X = System.Convert.ToBase64String(pubkeyBytes),
 			};
 			return key;
 		}

--- a/Contrib/Auth/Did/DidKeyResolver.cs
+++ b/Contrib/Auth/Did/DidKeyResolver.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Base128 = WojciechMikołajewicz.Base128;
 using Base58 = SimpleBase.Base58;
@@ -89,7 +87,7 @@ namespace Basis.Contrib.Auth.DecentralizedIds
 			{
 				Kty = "OKP",
 				Crv = "Ed25519",
-				X = System.Convert.ToBase64String(pubkeyBytes),
+				X = Base64UrlSafe.Encode(pubkeyBytes),
 			};
 			return key;
 		}

--- a/Contrib/Auth/Did/JsonWebKey.cs
+++ b/Contrib/Auth/Did/JsonWebKey.cs
@@ -1,0 +1,58 @@
+using System; // ReadOnlySpan
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Basis.Contrib.Auth.DecentralizedIds
+{
+	public class JsonWebKey
+	{
+		[JsonPropertyName("kty")]
+		public string? Kty { get; set; }
+
+		[JsonPropertyName("kid")]
+		public string? Kid { get; set; }
+
+		[JsonPropertyName("alg")]
+		public string? Alg { get; set; }
+
+		[JsonPropertyName("use")]
+		public string? Use { get; set; }
+
+		// Ed25519 parameters
+		[JsonPropertyName("x")]
+		public string? X { get; set; }
+
+		[JsonPropertyName("d")]
+		public string? D { get; set; }
+
+		[JsonPropertyName("crv")]
+		public string? Crv { get; set; }
+
+		// Symmetric key parameter
+		[JsonPropertyName("k")]
+		public string? K { get; set; }
+
+		// Helper method to exclude null values during serialization
+		public static JsonSerializerOptions SerializerOptions =>
+			new()
+			{
+				DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+				WriteIndented = true,
+			};
+
+		public string Serialize()
+		{
+			return JsonSerializer.Serialize(this, SerializerOptions);
+		}
+
+		public static JsonWebKey? Deserialize(string json)
+		{
+			return JsonSerializer.Deserialize<JsonWebKey>(json, SerializerOptions);
+		}
+
+		public static JsonWebKey? Deserialize(ReadOnlySpan<byte> json)
+		{
+			return JsonSerializer.Deserialize<JsonWebKey>(json, SerializerOptions);
+		}
+	}
+}


### PR DESCRIPTION
Motivator: packaging hard. Fewer package good. Yes.

This does add System.Text.Json as a dependency, but I *think* that since that is included as part of .netstandard2.1, it should already be a part of unity.

It also implements Base64UrlSafe encoding and decoding, with accompanying test.