### PR TITLE
Allow extending the Avatar SDK editor GUI

### DIFF
--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisAvatarSDKInspector.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisAvatarSDKInspector.cs
@@ -1,3 +1,4 @@
+using System;
 using Basis.Scripts.BasisSdk;
 using Basis.Scripts.BasisSdk.Helpers.Editor;
 using Basis.Scripts.Editor;
@@ -10,6 +11,7 @@ using UnityEngine.UIElements;
 [CustomEditor(typeof(BasisAvatar))]
 public partial class BasisAvatarSDKInspector : Editor
 {
+    public static event Action<BasisAvatarSDKInspector> InspectorGuiCreated;
     public VisualTreeAsset visualTree;
     public BasisAvatar Avatar;
 
@@ -43,6 +45,8 @@ public partial class BasisAvatarSDKInspector : Editor
             SetupItems();
             AvatarSDKJiggleBonesView.Initialize(this);
             AvatarSDKVisemes.Initialize(this);
+
+            InspectorGuiCreated?.Invoke(this);
         }
         else
         {


### PR DESCRIPTION
## Objective

I want to make a button to upload avatars to an S3 bucket. I want it to sit on the avatar sdk, near the button for building the asset bundle. 

## Solution

Add a public static event that passes along the inspector. 

With a `InitializeOnLoadAttribute` I can subscribe before the inspector is drawn. Then when the event is fired I can add my extra UI elements to the avatar sdk inspector. 


```C#
    [InitializeOnLoad]
    public static class S3AvatarUploader
    {
        static S3AvatarUploader()
        {
            BasisAvatarSDKInspector.InspectorGuiCreated += OnInspectorGuiCreated;
        }

        private static void OnInspectorGuiCreated(BasisAvatarSDKInspector inspector)
        {
            inspector.rootElement.Add(...);
        }
```

![image](https://github.com/user-attachments/assets/a2ed9bf2-31b6-4e8b-b940-841426e36c7d)