### PR TITLE
Fixing path in .vrmanifest to point to relative actions.json

### DIFF
--- a/Basis/unityProject.vrmanifest
+++ b/Basis/unityProject.vrmanifest
@@ -5,7 +5,7 @@
       "app_key": "application.generated.unity.basisunity.exe",
       "launch_type": "url",
       "url": "steam://launch/",
-      "action_manifest_path": "C:\\Users\\doola\\OneDrive\\Documents\\Github\\Basis Foundation\\Basis Unity\\Basis\\Assets\\StreamingAssets\\SteamVR\\actions.json",
+      "action_manifest_path": "Assets\\StreamingAssets\\SteamVR\\actions.json",
       "strings": {
         "en_us": {
           "name": "Basis Unity [Testing]"


### PR DESCRIPTION
This was pointing to hardcoded local developer path.

@dooly123 Does this make sense?

To be honest this is kind of a quick fix - ideally the `actions.json` should be in the user's appdata when the client is installed through steam, where the .vrmanifest can always reference it. That would be the long term fix imo.