### PR TITLE
BasisDistanceJobs: add hysteresis margin to prevent flapping

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/Transmitters/BasisDistanceJobs.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Transmitters/BasisDistanceJobs.cs
@@ -31,6 +31,14 @@ namespace Basis.Scripts.Networking.Transmitters
         [NativeDisableParallelForRestriction]
         public NativeArray<float> smallestDistance;
 
+        // Returns whether the distance is smaller or greater than the boundaryDistance but adds a margin to prevent flapping (hysteresis).
+        // We increase margin before exiting and we decrease margin before entering (the margin is a ratio).
+        private bool HysteresisDistance(bool wasInside, float sqrDistance, float boundaryDistance, float margin = 0.05f)
+        {
+            float hysteresis = wasInside ? +margin : -margin;
+            return sqrDistance < boundaryDistance * (1f + hysteresis);
+        }
+
         public void Execute(int index)
         {
             // Calculate distance
@@ -39,9 +47,9 @@ namespace Basis.Scripts.Networking.Transmitters
             distances[index] = sqrDistance;
 
             // Determine boolean results
-            DistanceResults[index] = sqrDistance < VoiceDistance;
-            HearingResults[index] = sqrDistance < HearingDistance;
-            AvatarResults[index] = sqrDistance < AvatarDistance;
+            DistanceResults[index] = HysteresisDistance(DistanceResults[index], sqrDistance, VoiceDistance);
+            HearingResults[index] = HysteresisDistance(HearingResults[index], sqrDistance, HearingDistance);
+            AvatarResults[index] = HysteresisDistance(AvatarResults[index], sqrDistance, AvatarDistance);
 
             // Update the smallest distance (atomic operation to avoid race conditions)
             float currentSmallest = smallestDistance[0];


### PR DESCRIPTION
Logic used for checks in DistanceBasedReduction may have flapping issues: an avatar could appear and disappear quickly because it's on the edge of the "Avatar range" setting. Towneh in discord reported the issue and I found interesting to solve the issue as a starting point to contribute. This only applies to the demo I think.

I've added a margin around the threshold distance depending on which state we're in: inside or outside it.
Towneh described this as a "grace distance gap between loading and unloading the avatar at the user setting configured distance".
This is a proposal as I haven't compiled the project myself yet (untested code). Feel free to give your opinion on this.