### PR TITLE
chore(ytdlp): recognise the renamed yt-dlp native package id

### DIFF
--- a/Basis/Packages/com.basis.integration.ytdlp/README.md
+++ b/Basis/Packages/com.basis.integration.ytdlp/README.md
@@ -58,9 +58,10 @@ BasisMediaSource source = await BasisYtDlpResolver.ResolveSourceAsync(pageUrl);
 
 ## Requirements
 
-- **`com.basis.mediaplayer`** (the player) and **`com.yewnyx.ytdlp`** (the in-process
-  yt-dlp native plugin — an embedded CPython runtime + yt-dlp). This package compiles
-  to nothing unless both are present (asmdef define constraints
+- **`com.basis.mediaplayer`** (the player) and **`town.mr.ytdlp`** (the in-process
+  yt-dlp native plugin — an embedded CPython runtime + yt-dlp; its pre-rename id
+  `com.yewnyx.ytdlp` is also recognised). This package compiles to nothing unless
+  both are present (asmdef define constraints
   `BASIS_MEDIAPLAYER_EXISTS` + `YTDLP_EXISTS`).
 - **Windows** today — the yt-dlp native plugin is Windows-first.
 - **Expect a few seconds per page-URL load.** The *first* resolution also unpacks the

--- a/Basis/Packages/com.basis.integration.ytdlp/Runtime/Basis.Integration.YtDlp.asmdef
+++ b/Basis/Packages/com.basis.integration.ytdlp/Runtime/Basis.Integration.YtDlp.asmdef
@@ -23,6 +23,11 @@
             "define": "BASIS_MEDIAPLAYER_EXISTS"
         },
         {
+            "name": "town.mr.ytdlp",
+            "expression": "",
+            "define": "YTDLP_EXISTS"
+        },
+        {
             "name": "com.yewnyx.ytdlp",
             "expression": "",
             "define": "YTDLP_EXISTS"

--- a/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpResolver.cs
+++ b/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpResolver.cs
@@ -8,7 +8,7 @@ using YtDlp;
 namespace Basis.Integration.YtDlp
 {
     /// <summary>
-    /// Bridges the in-process yt-dlp resolver (com.yewnyx.ytdlp) to BasisMediaPlayer:
+    /// Bridges the in-process yt-dlp resolver (town.mr.ytdlp) to BasisMediaPlayer:
     /// turns a page URL (YouTube, Twitch, …) into the stream(s) the OS-codec engine
     /// can open, then loads them. The core media player has no reference to this type,
     /// so removing this package removes the feature with nothing dangling.

--- a/Basis/Packages/com.basis.integration.ytdlp/TESTING.md
+++ b/Basis/Packages/com.basis.integration.ytdlp/TESTING.md
@@ -4,12 +4,13 @@ How to verify page-URL resolution (YouTube, Twitch, and friends) after changing 
 The base player's guide —
 [`com.basis.mediaplayer/TESTING.md`](../com.basis.mediaplayer/TESTING.md) — covers everything
 downstream of resolution and deliberately uses **direct stream URLs only**; page URLs belong
-here, because they only work when this integration (and its `com.yewnyx.ytdlp` dependency)
+here, because they only work when this integration (and its `town.mr.ytdlp` dependency)
 is installed.
 
 ## Prerequisites
 
-- `com.basis.mediaplayer` and `com.yewnyx.ytdlp` present — this package compiles to nothing
+- `com.basis.mediaplayer` and `town.mr.ytdlp` (or its pre-rename id `com.yewnyx.ytdlp`)
+  present — this package compiles to nothing
   without both (asmdef define constraints), so first confirm it's actually active: loading a
   page URL without it reports that a resolver is needed.
 - **Windows** — the yt-dlp native plugin is Windows-first.

--- a/Basis/Packages/com.basis.integration.ytdlp/package.json
+++ b/Basis/Packages/com.basis.integration.ytdlp/package.json
@@ -2,7 +2,7 @@
   "name": "com.basis.integration.ytdlp",
   "displayName": "Basis yt-dlp Integration",
   "version": "0.0.1",
-  "description": "Resolves page URLs (YouTube, Twitch, …) to playable stream URLs via the in-process yt-dlp native plugin (com.yewnyx.ytdlp) and hands them to BasisMediaPlayer. Optional bolt-on: compiles to nothing unless both com.basis.mediaplayer and com.yewnyx.ytdlp are present.",
+  "description": "Resolves page URLs (YouTube, Twitch, …) to playable stream URLs via the in-process yt-dlp native plugin (town.mr.ytdlp, or its pre-rename id com.yewnyx.ytdlp) and hands them to BasisMediaPlayer. Optional bolt-on: compiles to nothing unless both com.basis.mediaplayer and the yt-dlp plugin are present.",
   "author": {
     "name": "BasisVR",
     "url": "https://github.com/BasisVR"


### PR DESCRIPTION
## Summary
The native yt-dlp plugin this integration binds to was renamed from `com.yewnyx.ytdlp` to `town.mr.ytdlp` (the original repository is gone; the maintained copy lives at [towneh/dlp-native](https://github.com/towneh/dlp-native), released as v0.3.0). This adds the new id to the asmdef's versionDefines so `YTDLP_EXISTS` is defined for either name, meaning anyone still on the old package keeps compiling, and updates the docs to name the current id. No hard dependency is added; the package still compiles to nothing when the plugin is absent.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
The change is one asmdef `versionDefines` entry plus doc wording; no runtime code paths are touched, so the performance-related required checks are all N/A and ticked per the instructions above.

Tested on Windows in the editor: with only `town.mr.ytdlp` installed, the integration compiles (the new define fires) and a YouTube page URL resolved and played through BasisMediaPlayer. The old id keeps working because its versionDefines entry is retained, not replaced. Both packages installed at once was also considered: Unity fails compilation loudly on the duplicate `YtDlp.Runtime` assembly, so there is no silent wrong-pick to guard against here.
