### PR TITLE
Simplify CompactMerged with raw transport entries

### DIFF
--- a/Basis Server/BasisNetworkCore/BasisNetworkVersion.cs
+++ b/Basis Server/BasisNetworkCore/BasisNetworkVersion.cs
@@ -4,11 +4,10 @@ namespace Basis.Network.Core
     {
         // 52: restricted-DOF bone encoding — 2-DOF limb/extremity joints and 1-DOF toes ship
         // quantized angles instead of smallest-three quaternions (wire-format change).
-        // 53: hybrid avatar-bundle codec. Byte 0 of the channel-52 bundle header was a message
-        // count that every decoder documented as a hint and none read; it now carries the codec
-        // id and dictionary generation. A v52 client ignores that byte, so it would LZ4-decode a
-        // Zstd bundle into garbage rather than reject it — the version gate is what prevents
-        // that, which is why this is a bump and not a capability negotiation.
-        public static ushort ServerVersion = 53;
+        // 53: hybrid avatar-bundle codec and developer CompactMerged framing. Byte 0 of the
+        // channel-52 bundle header was a message count that every decoder documented as a hint
+        // and none read; it now carries the codec id and dictionary generation.
+        // 54: CompactMerged mixed framing adds raw Ack/Channeled entries (wire-format change).
+        public static ushort ServerVersion = 54;
     }
 }

--- a/Basis Server/BasisNetworkCore/Encryption/BasisCryptoLayer.cs
+++ b/Basis Server/BasisNetworkCore/Encryption/BasisCryptoLayer.cs
@@ -15,7 +15,7 @@ namespace Basis.Network.Core
 	/// direction) established by an X25519 handshake; see <see cref="BasisCryptoHandshake"/>.
 	///
 	/// Only the user-data-bearing packet properties are encrypted (Unreliable,
-	/// Channeled, Merged). Connection setup, NAT, MTU and out-of-band probe packets
+	/// Channeled, Merged, CompactMerged). Connection setup, NAT, MTU and out-of-band probe packets
 	/// stay cleartext so the handshake itself never depends on a key being present.
 	///
 	/// Wire layout of an encrypted datagram:
@@ -29,10 +29,11 @@ namespace Basis.Network.Core
 		public const int Overhead = BasisAeadCipher.TagSize + CounterSize;
 
 		private const byte PropertyMask = 0x1F;
-		// Mirrors LiteNetLib.PacketProperty: Unreliable = 0, Channeled = 1, Merged = 12.
+		// Mirrors LiteNetLib.PacketProperty values used for user-data-bearing datagrams.
 		private const byte PropUnreliable = 0;
 		private const byte PropChanneled = 1;
 		private const byte PropMerged = 12;
+		private const byte PropCompactMerged = 18;
 
 		private sealed class Session
 		{
@@ -146,7 +147,8 @@ namespace Basis.Network.Core
 		}
 
 		private static bool IsEncryptable(byte property)
-			=> property == PropUnreliable || property == PropChanneled || property == PropMerged;
+			=> property == PropUnreliable || property == PropChanneled ||
+			   property == PropMerged || property == PropCompactMerged;
 
 		private static void DisposeSession(Session session)
 		{

--- a/Basis Server/BasisServerTests/CompactMergeStressTests.cs
+++ b/Basis Server/BasisServerTests/CompactMergeStressTests.cs
@@ -51,15 +51,22 @@ internal static class WireAssert
     internal static byte Property(byte[] datagram) => (byte)(datagram[0] & PropertyMask);
 
     /// <summary>Walks a CompactMerged datagram, returning the entries or throwing on ragged framing.</summary>
-    internal static List<(byte Channel, byte[] Payload)> ParseCompact(byte[] datagram)
+    internal static List<(bool Raw, byte Channel, byte[] Payload)> ParseCompact(byte[] datagram)
     {
-        var entries = new List<(byte, byte[])>();
+        var entries = new List<(bool, byte, byte[])>();
         int offset = 1;
         while (offset < datagram.Length)
         {
-            Assert.True(CompactMerge.TryReadEntry(datagram, datagram.Length, ref offset, out byte channel, out int length),
+            Assert.True(
+                CompactMerge.TryReadEntry(
+                    datagram,
+                    datagram.Length,
+                    ref offset,
+                    out bool isRaw,
+                    out byte channel,
+                    out int length),
                 $"CompactMerged datagram of {datagram.Length} B has a ragged entry at {offset}");
-            entries.Add((channel, datagram.AsSpan(offset, length).ToArray()));
+            entries.Add((isRaw, channel, datagram.AsSpan(offset, length).ToArray()));
             offset += length;
         }
         Assert.Equal(datagram.Length, offset);
@@ -170,7 +177,7 @@ public class CompactMergeWireTests
 
             var byProperty = new Dictionary<byte, int>();
             var legacyContents = new Dictionary<byte, int>();
-            int compactEntries = 0, compactDatagrams = 0, multiEntryCompact = 0, legacyDatagrams = 0;
+            int compactEntries = 0, compactDatagrams = 0, multiEntryCompact = 0, legacyDatagrams = 0, rawCompactEntries = 0;
 
             foreach (byte[] datagram in layer.Outbound)
             {
@@ -184,7 +191,18 @@ public class CompactMergeWireTests
                     compactEntries += entries.Count;
                     if (entries.Count > 1) multiEntryCompact++;
                     foreach (var e in entries)
+                    {
                         Assert.True(e.Channel <= CompactMerge.ChannelMask);
+                        if (e.Raw)
+                        {
+                            rawCompactEntries++;
+                            Assert.True(e.Payload.Length >= NetConstants.ChanneledHeaderSize);
+                            byte nestedProperty = WireAssert.Property(e.Payload);
+                            Assert.True(
+                                nestedProperty == (byte)PacketPropertyMirror.Channeled || nestedProperty == (byte)PacketPropertyMirror.Ack,
+                                $"raw CompactMerged entry carried unexpected property {nestedProperty}");
+                        }
+                    }
                 }
                 else if (property == (byte)PacketPropertyMirror.Merged)
                 {
@@ -201,16 +219,11 @@ public class CompactMergeWireTests
             _out.WriteLine($"compact datagrams {compactDatagrams} carrying {compactEntries} entries ({multiEntryCompact} held more than one); legacy merged datagrams {legacyDatagrams}");
             _out.WriteLine($"legacy Merged entries by nested property: {string.Join(", ", legacyContents.OrderBy(k => k.Key).Select(k => $"{(PacketPropertyMirror)k.Key}={k.Value}"))}");
 
-            // Legacy Merged is not a compatibility path: it is the only container that can carry
-            // Ack and Channeled packets, which have no representation in the compact framing.
             Assert.DoesNotContain((byte)PacketPropertyMirror.Unreliable, legacyContents.Keys);
-            Assert.True(legacyContents.ContainsKey((byte)PacketPropertyMirror.Channeled)
-                     || legacyContents.ContainsKey((byte)PacketPropertyMirror.Ack),
-                "legacy Merged carried neither Channeled nor Ack, so it is not doing the job claimed for it");
-
             Assert.True(compactDatagrams > 0, "no CompactMerged datagram was emitted at all");
             Assert.True(multiEntryCompact > 0, "compact framing never actually merged anything");
-            Assert.True(legacyDatagrams > 0, "reliable traffic never produced a legacy Merged datagram, so the mixed case was not covered");
+            Assert.True(rawCompactEntries > 0, "reliable traffic never produced a raw Ack/Channeled CompactMerged entry");
+            Assert.Equal(0, legacyDatagrams);
         }
         finally
         {
@@ -367,7 +380,7 @@ public class CompactMergeFuzzTests
                 int length = rng.Next(0, 400);
                 byte[] source = new byte[2 + length];
                 rng.NextBytes(source);
-                written += CompactMerge.WriteEntry(buffer, written, (byte)rng.Next(0, 128), source, 2, length);
+                written += CompactMerge.WriteEntry(buffer, written, (byte)rng.Next(0, 64), source, 2, length);
             }
 
             int cut = rng.Next(0, written + 1);
@@ -453,7 +466,7 @@ public class CompactMergeFuzzTests
             int length = rng.Next(0, 130);
             byte[] payload = new byte[length];
             rng.NextBytes(payload);
-            byte channel = (byte)rng.Next(0, 128);
+            byte channel = (byte)rng.Next(0, 64);
 
             byte[] source = new byte[2 + length];
             payload.CopyTo(source, 2);

--- a/Basis Server/BasisServerTests/CompactMergeTests.cs
+++ b/Basis Server/BasisServerTests/CompactMergeTests.cs
@@ -60,7 +60,7 @@ public class CompactMergeFramingTests
     [InlineData(0, 0)]
     [InlineData(0, 1)]
     [InlineData(63, 32)]
-    [InlineData(127, 255)]
+    [InlineData(62, 255)]
     [InlineData(5, 256)]
     [InlineData(1, 1200)]
     public void WriteEntry_RoundTripsThroughTryReadEntry(byte channel, int payloadLength)
@@ -335,8 +335,8 @@ public class CompactMergeTransportTests
     [Fact]
     public void ChannelTooHighForCompactFraming_FallsBackWithoutCorruptingNeighbours()
     {
-        // The tag byte's top bit picks the length width, so channels above 127 cannot be compacted
-        // and drop back to legacy framing mid-stream -- the other half of the mode-switch flush.
+        // Bit 6 is now the raw Ack/Channeled marker, so unreliable channels above 63 cannot be
+        // compacted and drop back to legacy framing mid-stream.
         var (server, client, clientPeer) = Connect(serverCompact: true, clientCompact: true);
         using (server)
         using (client)
@@ -355,12 +355,20 @@ public class CompactMergeTransportTests
             Assert.True(WaitFor(() => server.Received.Count == sent.Count, DeliveryTimeoutMs),
                 $"expected {sent.Count} messages, got {server.Received.Count}");
 
-            var received = server.Received.ToArray();
-            for (int i = 0; i < sent.Count; i++)
+            // Unreliable delivery is intentionally unordered. Out-of-range channels bypass the
+            // compact accumulator directly, so they can overtake a held compact entry. Validate
+            // exact channel/content preservation without imposing an ordering guarantee.
+            var outstanding = sent
+                .Select(s => (s.Channel, Key: Convert.ToBase64String(s.Data)))
+                .ToList();
+            foreach (var got in server.Received)
             {
-                Assert.Equal(sent[i].Channel, received[i].Channel);
-                Assert.Equal(sent[i].Data, received[i].Data);
+                string key = Convert.ToBase64String(got.Data);
+                int index = outstanding.FindIndex(o => o.Channel == got.Channel && o.Key == key);
+                Assert.True(index >= 0, $"received an unexpected unreliable message on channel {got.Channel}");
+                outstanding.RemoveAt(index);
             }
+            Assert.Empty(outstanding);
         }
     }
 

--- a/Basis Server/BasisServerTests/CompactMergedTests.cs
+++ b/Basis Server/BasisServerTests/CompactMergedTests.cs
@@ -1,0 +1,629 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using LiteNetLib;
+using LiteNetLib.Layers;
+using Xunit;
+
+namespace BasisServerTests;
+
+public sealed class CompactMergedTests
+{
+    private const byte UnreliableProperty = 0;
+    private const byte ChanneledProperty = 1;
+    private const byte AckProperty = 2;
+    private const byte MergedProperty = 12;
+    private const byte CompactMergedProperty = 18;
+
+    [Fact]
+    public void MixedCompact_EncodesBoundaryLengthsAndChannels()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 20);
+        pair.ClientLayer.ClearOutbound();
+
+        byte[] shortPayload = Filled(255, 0x31);
+        byte[] extendedPayload = Filled(256, 0x42);
+        pair.ClientPeer.Send(shortPayload, 63, DeliveryMethod.Unreliable);
+        pair.ClientPeer.Send(extendedPayload, 62, DeliveryMethod.Unreliable);
+
+        byte[] datagram = pair.ClientLayer.WaitForOutbound(CompactMergedProperty);
+        Assert.Equal(CompactMergedProperty, Property(datagram));
+
+        int offset = 1;
+        Assert.Equal(63, datagram[offset]);
+        Assert.Equal(255, datagram[offset + 1]);
+        offset += 2;
+        Assert.Equal(shortPayload, datagram.AsSpan(offset, shortPayload.Length).ToArray());
+        offset += shortPayload.Length;
+
+        Assert.Equal((byte)(0x80 | 62), datagram[offset]);
+        Assert.Equal(0, datagram[offset + 1]);
+        Assert.Equal(1, datagram[offset + 2]);
+        offset += 3;
+        Assert.Equal(extendedPayload, datagram.AsSpan(offset, extendedPayload.Length).ToArray());
+        offset += extendedPayload.Length;
+
+        Assert.Equal(datagram.Length, offset);
+        Assert.True(ParseCompactFully(datagram));
+        pair.WaitForServerReceives(2);
+        Assert.Contains(pair.ServerReceives, r => r.Channel == 63 && r.Data.SequenceEqual(shortPayload));
+        Assert.Contains(pair.ServerReceives, r => r.Channel == 62 && r.Data.SequenceEqual(extendedPayload));
+    }
+
+    [Fact]
+    public void ZeroLengthEntries_AreValidAndNotTerminators()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 20);
+        pair.ClientLayer.ClearOutbound();
+
+        pair.ClientPeer.Send(Array.Empty<byte>(), 3, DeliveryMethod.Unreliable);
+        pair.ClientPeer.Send(Array.Empty<byte>(), 4, DeliveryMethod.Unreliable);
+
+        byte[] datagram = pair.ClientLayer.WaitForOutbound(CompactMergedProperty);
+        Assert.Equal(new byte[] { 3, 0, 4, 0 }, datagram.AsSpan(1).ToArray());
+        Assert.True(ParseCompactFully(datagram));
+        pair.WaitForServerReceives(2);
+        Assert.Contains(pair.ServerReceives, r => r.Channel == 3 && r.Data.Length == 0);
+        Assert.Contains(pair.ServerReceives, r => r.Channel == 4 && r.Data.Length == 0);
+    }
+
+    [Fact]
+    public void SingleEntryCompactBatch_RewritesToNormalUnreliableWithoutExtraByte()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 10);
+
+        pair.ClientLayer.ClearOutbound();
+        byte[] shortPayload = Filled(10, 0x51);
+        pair.ClientPeer.Send(shortPayload, 63, DeliveryMethod.Unreliable);
+        byte[] shortDatagram = pair.ClientLayer.WaitForOutbound(UnreliableProperty);
+        Assert.Equal(2 + shortPayload.Length, shortDatagram.Length);
+        Assert.Equal(63, shortDatagram[1]);
+        Assert.Equal(shortPayload, shortDatagram.AsSpan(2).ToArray());
+
+        pair.ClientLayer.ClearOutbound();
+        byte[] extendedPayload = Filled(256, 0x62);
+        pair.ClientPeer.Send(extendedPayload, 63, DeliveryMethod.Unreliable);
+        byte[] extendedDatagram = pair.ClientLayer.WaitForOutbound(UnreliableProperty);
+        Assert.Equal(2 + extendedPayload.Length, extendedDatagram.Length);
+        Assert.Equal(63, extendedDatagram[1]);
+        Assert.Equal(extendedPayload, extendedDatagram.AsSpan(2).ToArray());
+    }
+
+    [Fact]
+    public void SingleRawEntry_SendsOriginalChanneledPacketWithoutOuterOverhead()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 10);
+        pair.ClientLayer.ClearOutbound();
+
+        byte[] payload = { 0x61, 0x62, 0x63 };
+        pair.ClientPeer.Send(payload, 2, DeliveryMethod.ReliableOrdered);
+
+        byte[] datagram = pair.ClientLayer.WaitForOutbound(ChanneledProperty);
+        Assert.Equal(4 + payload.Length, datagram.Length);
+        Assert.Equal(payload, datagram.AsSpan(4).ToArray());
+        pair.WaitForServerReceives(1);
+        Assert.Contains(pair.ServerReceives, r => r.Channel == 2 && r.Data.SequenceEqual(payload));
+    }
+
+    [Fact]
+    public void CompactMerged_ExactMtuFitFlushesBeforeNextEntry()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 20);
+        pair.ClientLayer.ClearOutbound();
+
+        pair.ClientPeer.Send(Filled(596, 0x21), 6, DeliveryMethod.Unreliable);
+        pair.ClientPeer.Send(Filled(597, 0x22), 7, DeliveryMethod.Unreliable);
+        pair.ClientPeer.Send(new byte[] { 0x23 }, 8, DeliveryMethod.Unreliable);
+
+        byte[] datagram = pair.ClientLayer.WaitForOutbound(CompactMergedProperty);
+        Assert.Equal(1200, datagram.Length);
+        Assert.True(ParseCompactFully(datagram));
+        pair.WaitForServerReceives(3);
+    }
+
+    [Fact]
+    public void CompactMerged_DirectThresholdUsesCompactRepresentation()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 10);
+
+        pair.ClientPeer.Send(Filled(1175, 0x33), 9, DeliveryMethod.Unreliable);
+        byte[] optimized = pair.ClientLayer.WaitForOutbound(UnreliableProperty);
+        Assert.Equal(1177, optimized.Length);
+
+        pair.ClientLayer.ClearOutbound();
+        pair.ClientPeer.Send(Filled(1176, 0x34), 9, DeliveryMethod.Unreliable);
+        byte[] direct = pair.ClientLayer.WaitForOutbound(UnreliableProperty);
+        Assert.Equal(1178, direct.Length);
+    }
+
+    [Fact]
+    public void OutOfRangeUnreliable_DoesNotFlushPendingCompactBuffer()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 250);
+        pair.ClientLayer.ClearOutbound();
+
+        pair.ClientPeer.Send(new byte[] { 0x41 }, 1, DeliveryMethod.Unreliable);
+        Thread.Sleep(25);
+        Assert.DoesNotContain(
+            pair.ClientLayer.OutboundSnapshot(),
+            p => Property(p) == UnreliableProperty && p.Length > 1 && p[1] == 1);
+
+        pair.ClientPeer.Send(new byte[] { 0x42 }, 64, DeliveryMethod.Unreliable);
+        WaitUntil(
+            () => pair.ClientLayer.OutboundSnapshot().Any(
+                p => Property(p) == UnreliableProperty && p.Length == 3 && p[1] == 64),
+            "out-of-range direct unreliable send");
+
+        Thread.Sleep(50);
+        Assert.DoesNotContain(
+            pair.ClientLayer.OutboundSnapshot(),
+            p => Property(p) == UnreliableProperty && p.Length > 1 && p[1] == 1);
+
+        WaitUntil(
+            () => pair.ClientLayer.OutboundSnapshot().Any(
+                p => Property(p) == UnreliableProperty && p.Length == 3 && p[1] == 1),
+            "held compact unreliable send");
+        pair.WaitForServerReceives(2);
+    }
+
+    [Theory]
+    [InlineData((byte)64)]
+    [InlineData((byte)127)]
+    [InlineData((byte)128)]
+    public void ChannelsAbove63_BypassCompactWithoutMasking(byte channel)
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 20);
+        pair.ClientLayer.ClearOutbound();
+
+        pair.ClientPeer.Send(new byte[] { 0x71 }, channel, DeliveryMethod.Unreliable);
+        byte[] datagram = pair.ClientLayer.WaitForOutbound(UnreliableProperty);
+
+        Assert.Equal(3, datagram.Length);
+        Assert.Equal(channel, datagram[1]);
+        Assert.Equal(0x71, datagram[2]);
+        Assert.DoesNotContain(pair.ClientLayer.OutboundSnapshot(), p => Property(p) == MergedProperty);
+    }
+
+    [Fact]
+    public void AckAndChanneled_AreRawEntriesInsideCompactMerged()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 100);
+        pair.ClientLayer.ClearOutbound();
+        pair.ServerLayer.ClearOutbound();
+
+        pair.ClientPeer.Send(new byte[] { 0xC1 }, 2, DeliveryMethod.ReliableOrdered);
+        pair.ClientPeer.Send(new byte[] { 0xA1 }, 1, DeliveryMethod.Unreliable);
+
+        WaitUntil(
+            () => pair.ServerReceives.Any(r => r.Channel == 2 && r.Method == DeliveryMethod.ReliableOrdered),
+            "server reliable receive");
+        pair.ServerPeer.Send(new byte[] { 0xB1 }, 4, DeliveryMethod.Unreliable);
+
+        Thread.Sleep(130);
+
+        byte[][] clientDatagrams = pair.ClientLayer.OutboundSnapshot();
+        Assert.DoesNotContain(clientDatagrams, p => Property(p) == MergedProperty);
+        CompactEntry[] clientEntries = clientDatagrams
+            .Where(p => Property(p) == CompactMergedProperty)
+            .SelectMany(ParseCompactEntries)
+            .ToArray();
+        Assert.Contains(clientEntries, e => e.IsRaw && Property(e.Data) == ChanneledProperty);
+        Assert.Contains(clientEntries, e => !e.IsRaw && e.Channel == 1 && e.Data.SequenceEqual(new byte[] { 0xA1 }));
+
+        byte[][] serverDatagrams = pair.ServerLayer.OutboundSnapshot();
+        Assert.DoesNotContain(serverDatagrams, p => Property(p) == MergedProperty);
+        CompactEntry[] serverEntries = serverDatagrams
+            .Where(p => Property(p) == CompactMergedProperty)
+            .SelectMany(ParseCompactEntries)
+            .ToArray();
+        Assert.Contains(serverEntries, e => e.IsRaw && Property(e.Data) == AckProperty);
+        Assert.Contains(serverEntries, e => !e.IsRaw && e.Channel == 4 && e.Data.SequenceEqual(new byte[] { 0xB1 }));
+    }
+
+    [Fact]
+    public void RawChanneled_ExtendedEntryRoundTrips()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 100);
+        pair.ClientLayer.ClearOutbound();
+
+        byte[] reliablePayload = Filled(300, 0x5A);
+        pair.ClientPeer.Send(reliablePayload, 2, DeliveryMethod.ReliableOrdered);
+        pair.ClientPeer.Send(new byte[] { 0x22 }, 1, DeliveryMethod.Unreliable);
+
+        byte[] datagram = pair.ClientLayer.WaitForOutbound(CompactMergedProperty);
+        CompactEntry[] entries = ParseCompactEntries(datagram);
+        Assert.Contains(entries, e => e.IsRaw && e.Data.Length == 304 && Property(e.Data) == ChanneledProperty);
+        pair.WaitForServerReceives(2);
+        Assert.Contains(pair.ServerReceives, r => r.Channel == 2 && r.Data.SequenceEqual(reliablePayload));
+    }
+
+    [Fact]
+    public void FragmentedChanneled_FinalFragmentCanTravelAsRawCompactEntry()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 20);
+        pair.ClientLayer.ClearOutbound();
+
+        byte[] reliablePayload = Filled(1300, 0x6A);
+        pair.ClientPeer.Send(reliablePayload, 2, DeliveryMethod.ReliableOrdered);
+        pair.ClientPeer.Send(new byte[] { 0x7E }, 1, DeliveryMethod.Unreliable);
+
+        pair.WaitForServerReceives(2);
+        Assert.Contains(
+            pair.ServerReceives,
+            r => r.Channel == 2 && r.Method == DeliveryMethod.ReliableOrdered && r.Data.SequenceEqual(reliablePayload));
+        Assert.Contains(
+            pair.ServerReceives,
+            r => r.Channel == 1 && r.Method == DeliveryMethod.Unreliable && r.Data.SequenceEqual(new byte[] { 0x7E }));
+
+        byte[][] compactDatagrams = pair.ClientLayer.OutboundSnapshot()
+            .Where(p => Property(p) == CompactMergedProperty)
+            .ToArray();
+        Assert.Contains(
+            compactDatagrams.SelectMany(ParseCompactEntries),
+            e => e.IsRaw && Property(e.Data) == ChanneledProperty && (e.Data[0] & 0x80) != 0);
+    }
+
+    [Fact]
+    public void OversizedChanneled_FlushesEarlierBufferedEntryBeforeDirectSend()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 500);
+        pair.ClientLayer.ClearOutbound();
+
+        pair.ClientPeer.Send(new byte[] { 0x31 }, 1, DeliveryMethod.Unreliable);
+        Thread.Sleep(20);
+        pair.ClientPeer.Send(Filled(1197, 0x6B), 2, DeliveryMethod.ReliableOrdered);
+
+        WaitUntil(
+            () => pair.ClientLayer.OutboundSnapshot().Any(p => Property(p) == ChanneledProperty),
+            "oversized direct channeled send");
+        byte[][] datagrams = pair.ClientLayer.OutboundSnapshot();
+        int bufferedIndex = Array.FindIndex(
+            datagrams,
+            p => Property(p) == UnreliableProperty && p.Length == 3 && p[1] == 1 && p[2] == 0x31);
+        int directIndex = Array.FindIndex(datagrams, p => Property(p) == ChanneledProperty);
+        Assert.True(bufferedIndex >= 0);
+        Assert.True(directIndex > bufferedIndex);
+    }
+
+    [Theory]
+    [MemberData(nameof(MalformedCompactBodies))]
+    public void MalformedCompactMerged_IsDroppedWithoutBreakingPeer(byte[] compactBody)
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 0);
+        int receivedBefore = pair.ServerReceives.Count;
+        int poolBefore = pair.Server.PoolCount;
+
+        pair.ServerLayer.ReplaceNextInboundUnreliableWithCompact(compactBody);
+        pair.ClientPeer.Send(new byte[] { 0xEE }, 0, DeliveryMethod.Unreliable);
+        Thread.Sleep(40);
+        Assert.Equal(receivedBefore, pair.ServerReceives.Count);
+
+        byte[] valid = { 0xAB, 0xCD };
+        pair.ClientPeer.Send(valid, 0, DeliveryMethod.Unreliable);
+        pair.WaitForServerReceives(receivedBefore + 1);
+        Assert.Equal(valid, pair.ServerReceives.Last().Data);
+        Assert.True(pair.Server.PoolCount >= poolBefore - 2);
+    }
+
+    [Fact]
+    public void EmptyCompactMergedOuter_IsValidAndRecycled()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 0);
+        int receivedBefore = pair.ServerReceives.Count;
+        int poolBefore = pair.Server.PoolCount;
+
+        pair.ServerLayer.ReplaceNextInboundUnreliableWithCompact(Array.Empty<byte>());
+        pair.ClientPeer.Send(new byte[] { 0xEE }, 0, DeliveryMethod.Unreliable);
+        Thread.Sleep(40);
+
+        Assert.Equal(receivedBefore, pair.ServerReceives.Count);
+        Assert.True(pair.Server.PoolCount >= poolBefore - 2);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(31)]
+    [InlineData(32)]
+    [InlineData(62)]
+    [InlineData(63)]
+    public void CompactMerged_SixBitChannels_RoundTrip(byte channel)
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 20);
+        pair.ClientLayer.ClearOutbound();
+
+        pair.ClientPeer.Send(new byte[] { 0x91 }, channel, DeliveryMethod.Unreliable);
+        pair.ClientPeer.Send(new byte[] { 0x92 }, channel, DeliveryMethod.Unreliable);
+
+        byte[] datagram = pair.ClientLayer.WaitForOutbound(CompactMergedProperty);
+        Assert.Equal(channel, datagram[1]);
+        Assert.True(ParseCompactFully(datagram));
+        pair.WaitForServerReceives(2);
+        Assert.All(pair.ServerReceives, received => Assert.Equal(channel, received.Channel));
+    }
+
+    [Fact]
+    public void CompactMerged_MaxChannelAndZeroPayload_RoundTrip()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 0);
+        int before = pair.ServerReceives.Count;
+
+        pair.ServerLayer.ReplaceNextInboundUnreliableWithCompact(new byte[] { 63, 0 });
+        pair.ClientPeer.Send(new byte[] { 0xEE }, 0, DeliveryMethod.Unreliable);
+        pair.WaitForServerReceives(before + 1);
+
+        Received received = pair.ServerReceives.Last();
+        Assert.Equal(63, received.Channel);
+        Assert.Empty(received.Data);
+    }
+
+    [Fact]
+    public void MalformedCompactMerged_StopsBeforeLaterEntries()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 0);
+        int before = pair.ServerReceives.Count;
+
+        pair.ServerLayer.ReplaceNextInboundUnreliableWithCompact(
+            new byte[] { 3, 1, 0xA1, 4, 5, 0xB1, 5, 1, 0xC1 });
+        pair.ClientPeer.Send(new byte[] { 0xEE }, 0, DeliveryMethod.Unreliable);
+        pair.WaitForServerReceives(before + 1);
+        Thread.Sleep(30);
+
+        Received[] received = pair.ServerReceives.Skip(before).ToArray();
+        Assert.Single(received);
+        Assert.Equal(3, received[0].Channel);
+        Assert.Equal(new byte[] { 0xA1 }, received[0].Data);
+    }
+
+    [Fact]
+    public void OversizedReconstructedPacket_IsRejectedBeforeInnerPacketRent()
+    {
+        using var pair = new LoopbackPair(mergeHoldMs: 0);
+        int before = pair.ServerReceives.Count;
+        int poolBefore = pair.Server.PoolCount;
+
+        byte[] body = new byte[3 + ushort.MaxValue];
+        body[0] = 0x80;
+        body[1] = 0xFF;
+        body[2] = 0xFF;
+        pair.ServerLayer.ReplaceNextInboundUnreliableWithCompact(body);
+        pair.ClientPeer.Send(new byte[] { 0xEE }, 0, DeliveryMethod.Unreliable);
+        Thread.Sleep(40);
+
+        Assert.Equal(before, pair.ServerReceives.Count);
+        Assert.True(pair.Server.PoolCount >= poolBefore - 2);
+
+        pair.ClientPeer.Send(new byte[] { 0x7A }, 0, DeliveryMethod.Unreliable);
+        pair.WaitForServerReceives(before + 1);
+    }
+
+    public static IEnumerable<object[]> MalformedCompactBodies()
+    {
+        yield return new object[] { new byte[] { 5 } };
+        yield return new object[] { new byte[] { 0x85, 0x01 } };
+        yield return new object[] { new byte[] { 5, 3, 0x10 } };
+        yield return new object[] { new byte[] { 0x85, 0x00, 0x01, 0x10 } };
+        yield return new object[] { new byte[] { 0x85, 1, 0, 0x10 } };
+        yield return new object[] { new byte[] { 0x41, 4, 2, 0, 0, 0 } };
+        yield return new object[] { new byte[] { 0x40, 1, 2 } };
+        yield return new object[] { new byte[] { 0x40, 4, 0, 0, 0, 0 } };
+        yield return new object[] { new byte[] { 0x40, 4, 18, 0, 0, 0 } };
+    }
+
+    private static byte[] Filled(int length, byte value)
+    {
+        byte[] result = new byte[length];
+        Array.Fill(result, value);
+        return result;
+    }
+
+    private static byte Property(ReadOnlySpan<byte> datagram) => (byte)(datagram[0] & 0x1F);
+
+    private sealed record CompactEntry(bool IsRaw, byte Channel, byte[] Data);
+
+    private static CompactEntry[] ParseCompactEntries(byte[] datagram)
+    {
+        if (datagram.Length < 1 || Property(datagram) != CompactMergedProperty)
+            throw new InvalidOperationException("Not a CompactMerged datagram.");
+
+        var entries = new List<CompactEntry>();
+        int offset = 1;
+        while (offset < datagram.Length)
+        {
+            if (datagram.Length - offset < 2)
+                throw new InvalidOperationException("Truncated CompactMerged entry header.");
+
+            byte channelAndFlags = datagram[offset];
+            bool extended = (channelAndFlags & 0x80) != 0;
+            bool isRaw = (channelAndFlags & 0x40) != 0;
+            byte channel = (byte)(channelAndFlags & 0x3F);
+            if (isRaw && channel != 0)
+                throw new InvalidOperationException("Raw entry has nonzero channel bits.");
+
+            int header = extended ? 3 : 2;
+            if (datagram.Length - offset < header)
+                throw new InvalidOperationException("Truncated CompactMerged extended header.");
+
+            int length = extended
+                ? datagram[offset + 1] | (datagram[offset + 2] << 8)
+                : datagram[offset + 1];
+            if (extended && length <= 255)
+                throw new InvalidOperationException("Non-canonical extended CompactMerged length.");
+
+            offset += header;
+            if (length > datagram.Length - offset)
+                throw new InvalidOperationException("CompactMerged entry exceeds datagram.");
+
+            byte[] data = datagram.AsSpan(offset, length).ToArray();
+            if (isRaw)
+            {
+                if (data.Length < 4 || Property(data) is not (AckProperty or ChanneledProperty))
+                    throw new InvalidOperationException("Invalid raw CompactMerged entry.");
+            }
+
+            entries.Add(new CompactEntry(isRaw, channel, data));
+            offset += length;
+        }
+
+        return entries.ToArray();
+    }
+
+    private static bool ParseCompactFully(byte[] datagram)
+    {
+        try
+        {
+            _ = ParseCompactEntries(datagram);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    private static void WaitUntil(Func<bool> condition, string description, int timeoutMs = 3000)
+    {
+        var sw = Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (sw.ElapsedMilliseconds >= timeoutMs)
+                throw new TimeoutException($"Timed out waiting for {description}.");
+            Thread.Sleep(2);
+        }
+    }
+
+    private sealed record Received(byte Channel, DeliveryMethod Method, byte[] Data);
+
+    private sealed class CaptureLayer : PacketLayerBase
+    {
+        private readonly ConcurrentQueue<byte[]> _outbound = new();
+        private byte[]? _compactReplacementBody;
+
+        public CaptureLayer() : base(0)
+        {
+        }
+
+        public void ClearOutbound()
+        {
+            while (_outbound.TryDequeue(out _)) { }
+        }
+
+        public byte[][] OutboundSnapshot() => _outbound.ToArray();
+
+        public byte[] WaitForOutbound(byte property, int timeoutMs = 3000)
+        {
+            byte[]? found = null;
+            WaitUntil(() =>
+            {
+                foreach (byte[] packet in _outbound)
+                {
+                    if (Property(packet) == property)
+                    {
+                        found = packet;
+                        return true;
+                    }
+                }
+                return false;
+            }, $"outbound packet property {property}", timeoutMs);
+            return found!;
+        }
+
+        public void ReplaceNextInboundUnreliableWithCompact(byte[] compactBody)
+        {
+            Interlocked.Exchange(ref _compactReplacementBody, compactBody.ToArray());
+        }
+
+        public override void ProcessOutBoundPacket(ref IPEndPoint endPoint, ref byte[] data, ref int offset, ref int length)
+        {
+            byte[] copy = new byte[length];
+            Buffer.BlockCopy(data, offset, copy, 0, length);
+            _outbound.Enqueue(copy);
+        }
+
+        public override void ProcessInboundPacket(ref IPEndPoint endPoint, ref byte[] data, ref int length)
+        {
+            if (length < 1 || Property(data.AsSpan(0, length)) != UnreliableProperty)
+                return;
+
+            byte[]? body = Interlocked.Exchange(ref _compactReplacementBody, null);
+            if (body == null)
+                return;
+
+            byte[] replacement = new byte[1 + body.Length];
+            replacement[0] = (byte)((data[0] & 0xE0) | CompactMergedProperty);
+            body.CopyTo(replacement, 1);
+            data = replacement;
+            length = replacement.Length;
+        }
+    }
+
+    private sealed class LoopbackPair : IDisposable
+    {
+        private readonly ManualResetEventSlim _clientConnected = new(false);
+        private readonly ManualResetEventSlim _serverConnected = new(false);
+
+        public CaptureLayer ServerLayer { get; } = new();
+        public CaptureLayer ClientLayer { get; } = new();
+        public NetManager Server { get; }
+        public NetManager Client { get; }
+        public NetPeer ServerPeer { get; private set; } = null!;
+        public NetPeer ClientPeer { get; private set; } = null!;
+        public ConcurrentQueue<Received> ServerReceives { get; } = new();
+
+        public LoopbackPair(float mergeHoldMs)
+        {
+            var serverListener = new EventBasedNetListener();
+            var clientListener = new EventBasedNetListener();
+
+            serverListener.ConnectionRequestEvent += request => request.AcceptIfKey("compact-test");
+            serverListener.PeerConnectedEvent += peer =>
+            {
+                ServerPeer = peer;
+                _serverConnected.Set();
+            };
+            clientListener.PeerConnectedEvent += peer =>
+            {
+                ClientPeer = peer;
+                _clientConnected.Set();
+            };
+            serverListener.NetworkReceiveEvent += (_, reader, channel, method) =>
+                ServerReceives.Enqueue(new Received(channel, method, reader.GetRemainingBytes()));
+
+            Server = CreateManager(serverListener, ServerLayer, mergeHoldMs);
+            Client = CreateManager(clientListener, ClientLayer, mergeHoldMs);
+
+            Assert.True(Server.Start(0));
+            Assert.True(Client.Start(0));
+            Client.Connect("127.0.0.1", Server.LocalPort, "compact-test");
+            Assert.True(_serverConnected.Wait(3000), "Server peer did not connect.");
+            Assert.True(_clientConnected.Wait(3000), "Client peer did not connect.");
+            Thread.Sleep(15);
+        }
+
+        private static NetManager CreateManager(EventBasedNetListener listener, CaptureLayer layer, float mergeHoldMs)
+        {
+            return new NetManager(listener, layer)
+            {
+                UnsyncedEvents = true,
+                AutoRecycle = true,
+                ChannelsCount = 64,
+                UpdateTime = 2,
+                MtuDiscovery = false,
+                MtuOverride = 1200,
+                MergeHoldMs = mergeHoldMs,
+                CompactMergeEnabled = true,
+                EnableStatistics = true
+            };
+        }
+
+        public void WaitForServerReceives(int expected, int timeoutMs = 3000) =>
+            WaitUntil(() => ServerReceives.Count >= expected, $"{expected} server receive events", timeoutMs);
+
+        public void Dispose()
+        {
+            Client.Stop(false);
+            Server.Stop(false);
+            _clientConnected.Dispose();
+            _serverConnected.Dispose();
+        }
+    }
+}

--- a/Basis Server/BasisServerTests/CryptoHandshakeAndLayerTests.cs
+++ b/Basis Server/BasisServerTests/CryptoHandshakeAndLayerTests.cs
@@ -22,6 +22,7 @@ public class CryptoHandshakeAndLayerTests
     private const byte HeaderUnreliable = 0x00;
     private const byte HeaderChanneled = 0x01;
     private const byte HeaderMerged = 0x0C;
+    private const byte HeaderCompactMerged = 0x12;
 
     // ---------------------------------------------------------------- helpers
 
@@ -647,6 +648,7 @@ public class CryptoHandshakeAndLayerTests
     [InlineData(HeaderUnreliable)]
     [InlineData(HeaderChanneled)]
     [InlineData(HeaderMerged)]
+    [InlineData(HeaderCompactMerged)]
     [InlineData((byte)0xE1)] // Channeled with high header bits set
     [InlineData((byte)0x8C)] // Merged with high header bit set
     public void EncryptableProperties_AreEncrypted_IncludingMaskedHeaderBits(byte header)

--- a/Basis Server/LiteNetLib/CompactMerge.cs
+++ b/Basis Server/LiteNetLib/CompactMerge.cs
@@ -6,19 +6,16 @@ namespace LiteNetLib
     /// <summary>
     /// Entry framing for <see cref="PacketProperty.CompactMerged"/> datagrams.
     ///
-    /// <para>Entry layout: <c>[channel | LongLengthFlag][length][payload]</c>, where length is one
-    /// byte, or two when <see cref="LongLengthFlag"/> is set on the channel byte. A
-    /// <see cref="PacketProperty.Merged"/> entry is <c>[ushort size][nested packet]</c> instead,
-    /// and the nested packet carries its own property and channel bytes.</para>
-    ///
-    /// <para>Only plain unreliable messages can be carried: the container property identifies the
-    /// entry type, so the per-entry property byte is dropped, and the channel is limited to
-    /// <see cref="ChannelMask"/> because the top bit selects the length width.</para>
+    /// <para>Bit 7 selects the extended 16-bit length form, bit 6 marks an opaque raw
+    /// Ack/Channeled packet, and bits 0-5 carry the application channel for compact
+    /// unreliable entries. LiteNetLib caps configured application channels at 64, so
+    /// all valid channels fit in six bits.</para>
     /// </summary>
     internal static class CompactMerge
     {
         internal const byte LongLengthFlag = 0x80;
-        internal const byte ChannelMask = 0x7F;
+        internal const byte RawPacketFlag = 0x40;
+        internal const byte ChannelMask = 0x3F;
         internal const int MaxShortLength = byte.MaxValue;
         internal const int ShortEntryOverhead = 2;
         internal const int LongEntryOverhead = 3;
@@ -38,56 +35,139 @@ namespace LiteNetLib
             return channel <= ChannelMask;
         }
 
-        /// <summary>Writes one entry at <paramref name="offset"/> and returns the bytes written.</summary>
-        internal static int WriteEntry(byte[] destination, int offset, byte channel, byte[] source, int sourceOffset, int payloadLength)
+        private static int WriteHeader(byte[] destination, int offset, byte tag, int payloadLength)
         {
-            int start = offset;
             if (payloadLength > MaxShortLength)
             {
-                destination[offset++] = (byte)(channel | LongLengthFlag);
+                destination[offset++] = (byte)(tag | LongLengthFlag);
                 FastBitConverter.GetBytes(destination, offset, (ushort)payloadLength);
-                offset += 2;
+                return LongEntryOverhead;
             }
-            else
-            {
-                destination[offset++] = channel;
-                destination[offset++] = (byte)payloadLength;
-            }
-            Buffer.BlockCopy(source, sourceOffset, destination, offset, payloadLength);
-            return offset + payloadLength - start;
+
+            destination[offset] = tag;
+            destination[offset + 1] = (byte)payloadLength;
+            return ShortEntryOverhead;
+        }
+
+        /// <summary>Writes one compact unreliable entry and returns the bytes written.</summary>
+        internal static int WriteUnreliableEntry(
+            byte[] destination,
+            int offset,
+            byte channel,
+            byte[] source,
+            int sourceOffset,
+            int payloadLength)
+        {
+            int overhead = WriteHeader(destination, offset, channel, payloadLength);
+            Buffer.BlockCopy(source, sourceOffset, destination, offset + overhead, payloadLength);
+            return overhead + payloadLength;
+        }
+
+        // Keep the original helper name for the existing direct codec tests and callers.
+        internal static int WriteEntry(
+            byte[] destination,
+            int offset,
+            byte channel,
+            byte[] source,
+            int sourceOffset,
+            int payloadLength) =>
+            WriteUnreliableEntry(destination, offset, channel, source, sourceOffset, payloadLength);
+
+        /// <summary>Writes one complete raw Ack/Channeled packet and returns the bytes written.</summary>
+        internal static int WriteRawEntry(
+            byte[] destination,
+            int offset,
+            byte[] source,
+            int sourceOffset,
+            int packetLength)
+        {
+            int overhead = WriteHeader(destination, offset, RawPacketFlag, packetLength);
+            Buffer.BlockCopy(source, sourceOffset, destination, offset + overhead, packetLength);
+            return overhead + packetLength;
         }
 
         /// <summary>
         /// Reads the entry header at <paramref name="offset"/>, leaving it on the first payload
-        /// byte. Returns false if the entry is truncated, in which case <paramref name="offset"/>
-        /// is left unusable and the caller must stop parsing.
+        /// byte. Raw entries are accepted only for Ack/Channeled packets, preventing recursive
+        /// CompactMerged nesting and keeping the raw escape canonical.
         /// </summary>
-        internal static bool TryReadEntry(byte[] source, int size, ref int offset, out byte channel, out int payloadLength)
+        internal static bool TryReadEntry(
+            byte[] source,
+            int size,
+            ref int offset,
+            out bool isRawPacket,
+            out byte channel,
+            out int payloadLength)
         {
+            isRawPacket = false;
             channel = 0;
             payloadLength = 0;
-            if (offset >= size)
+
+            if (source == null || size < 0 || size > source.Length || offset < 0 || size - offset < ShortEntryOverhead)
                 return false;
 
             byte tag = source[offset++];
+            isRawPacket = (tag & RawPacketFlag) != 0;
+            channel = (byte)(tag & ChannelMask);
+
+            // Raw entries have no application-channel field. Non-zero low bits would create
+            // alternate encodings of the same packet, so reject them.
+            if (isRawPacket && channel != 0)
+                return false;
+
             if ((tag & LongLengthFlag) != 0)
             {
                 if (size - offset < 2)
                     return false;
                 payloadLength = FastBitConverter.Read<ushort>(source, offset);
                 offset += 2;
+
+                // Keep one canonical encoding: <=255 always uses the short form.
+                if (payloadLength <= MaxShortLength)
+                    return false;
             }
             else
             {
-                if (offset >= size)
-                    return false;
                 payloadLength = source[offset++];
             }
 
-            if (size - offset < payloadLength)
+            if (payloadLength > size - offset)
                 return false;
 
-            channel = (byte)(tag & ChannelMask);
+            if (isRawPacket)
+            {
+                if (payloadLength < NetConstants.ChanneledHeaderSize || payloadLength > NetConstants.MaxPacketSize)
+                    return false;
+
+                PacketProperty property = (PacketProperty)(source[offset] & 0x1F);
+                if (property != PacketProperty.Ack && property != PacketProperty.Channeled)
+                    return false;
+            }
+            else if (payloadLength + NetConstants.UnreliableHeaderSize > NetConstants.MaxPacketSize)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        // Compatibility overload for existing codec tests that only decode unreliable entries.
+        internal static bool TryReadEntry(
+            byte[] source,
+            int size,
+            ref int offset,
+            out byte channel,
+            out int payloadLength)
+        {
+            int originalOffset = offset;
+            if (!TryReadEntry(source, size, ref offset, out bool isRawPacket, out channel, out payloadLength) || isRawPacket)
+            {
+                offset = originalOffset;
+                channel = 0;
+                payloadLength = 0;
+                return false;
+            }
+
             return true;
         }
     }

--- a/Basis Server/LiteNetLib/NetPeer.cs
+++ b/Basis Server/LiteNetLib/NetPeer.cs
@@ -1436,21 +1436,64 @@ namespace LiteNetLib
                     break;
 
                 case PacketProperty.CompactMerged:
-                    int compactPos = NetConstants.HeaderSize;
-                    while (compactPos < packet.Size)
+                    try
                     {
-                        if (!CompactMerge.TryReadEntry(packet.RawData, packet.Size, ref compactPos, out byte compactChannel, out int payloadLength))
-                            break;
+                        int compactPos = NetConstants.HeaderSize;
+                        while (compactPos < packet.Size)
+                        {
+                            if (!CompactMerge.TryReadEntry(
+                                    packet.RawData,
+                                    packet.Size,
+                                    ref compactPos,
+                                    out bool compactRawPacket,
+                                    out byte compactChannel,
+                                    out int payloadLength))
+                            {
+                                break;
+                            }
 
-                        NetPacket unreliable = NetManager.PoolGetPacket(NetConstants.UnreliableHeaderSize + payloadLength);
-                        unreliable.RawData[0] = (byte)PacketProperty.Unreliable;
-                        unreliable.RawData[1] = compactChannel;
-                        Buffer.BlockCopy(packet.RawData, compactPos, unreliable.RawData, NetConstants.UnreliableHeaderSize, payloadLength);
-                        compactPos += payloadLength;
+                            int payloadOffset = compactPos;
+                            compactPos += payloadLength;
 
-                        NetManager.CreateReceiveEvent(unreliable, DeliveryMethod.Unreliable, compactChannel, NetConstants.UnreliableHeaderSize, this);
+                            if (compactRawPacket)
+                            {
+                                NetPacket innerPacket = NetManager.PoolGetPacket(payloadLength);
+                                Buffer.BlockCopy(packet.RawData, payloadOffset, innerPacket.RawData, 0, payloadLength);
+                                innerPacket.Size = payloadLength;
+                                if (!innerPacket.Verify())
+                                {
+                                    NetManager.PoolRecycle(innerPacket);
+                                    break;
+                                }
+
+                                ProcessPacket(innerPacket);
+                                continue;
+                            }
+
+                            NetPacket unreliable = NetManager.PoolGetPacket(NetConstants.UnreliableHeaderSize + payloadLength);
+                            unreliable.RawData[0] = (byte)PacketProperty.Unreliable;
+                            unreliable.ConnectionNumber = _connectNum;
+                            unreliable.RawData[1] = compactChannel;
+                            Buffer.BlockCopy(
+                                packet.RawData,
+                                payloadOffset,
+                                unreliable.RawData,
+                                NetConstants.UnreliableHeaderSize,
+                                payloadLength);
+                            unreliable.Size = NetConstants.UnreliableHeaderSize + payloadLength;
+
+                            NetManager.CreateReceiveEvent(
+                                unreliable,
+                                DeliveryMethod.Unreliable,
+                                compactChannel,
+                                NetConstants.UnreliableHeaderSize,
+                                this);
+                        }
                     }
-                    NetManager.PoolRecycle(packet);
+                    finally
+                    {
+                        NetManager.PoolRecycle(packet);
+                    }
                     break;
 
                 //If we get ping, send pong
@@ -1519,35 +1562,80 @@ namespace LiteNetLib
         {
             if (_mergeCount == 0)
                 return;
+
             int bytesSent;
+
             // Batchable: this is bulk payload traffic and nothing reads the result beyond stats.
             // Outside a batching window this is exactly the old direct send.
             if (_mergeCount > 1)
             {
-                //NetDebug.Write("[P]Send merged: " + _mergePos + ", count: " + _mergeCount);
-                bytesSent = NetManager.SendRawBatchable(_mergeData.RawData, 0, NetConstants.HeaderSize + _mergePos, this);
+                bytesSent = NetManager.SendRawBatchable(
+                    _mergeData.RawData,
+                    0,
+                    NetConstants.HeaderSize + _mergePos,
+                    this);
             }
             else if (_mergeCompact)
             {
-                //Send a lone entry as the unreliable packet it was built from
                 int entryPos = NetConstants.HeaderSize;
-                if (CompactMerge.TryReadEntry(_mergeData.RawData, NetConstants.HeaderSize + _mergePos, ref entryPos, out byte channel, out int payloadLength))
+                if (!CompactMerge.TryReadEntry(
+                        _mergeData.RawData,
+                        NetConstants.HeaderSize + _mergePos,
+                        ref entryPos,
+                        out bool isRawPacket,
+                        out byte channel,
+                        out int payloadLength))
                 {
-                    Buffer.BlockCopy(_mergeData.RawData, entryPos, _mergeData.RawData, NetConstants.UnreliableHeaderSize, payloadLength);
-                    _mergeData.RawData[0] = (byte)((byte)PacketProperty.Unreliable | (_connectNum << 5));
-                    _mergeData.RawData[1] = channel;
-                    bytesSent = NetManager.SendRawBatchable(_mergeData.RawData, 0, NetConstants.UnreliableHeaderSize + payloadLength, this);
+                    byte firstEntryByte0 = _mergePos > 0
+                        ? _mergeData.RawData[NetConstants.HeaderSize]
+                        : (byte)0;
+                    byte firstEntryByte1 = _mergePos > 1
+                        ? _mergeData.RawData[NetConstants.HeaderSize + 1]
+                        : (byte)0;
+                    NetDebug.WriteError(
+                        $"[CompactMerged] Internal single-entry decode failure: count={_mergeCount}, " +
+                        $"pos={_mergePos}, entry0=0x{firstEntryByte0:X2}, entry1=0x{firstEntryByte1:X2}. " +
+                        "Dropping merge buffer.");
+                    _mergePos = 0;
+                    _mergeCount = 0;
+                    _mergeHeldMs = 0f;
+                    return;
+                }
+
+                if (isRawPacket)
+                {
+                    bytesSent = NetManager.SendRawBatchable(
+                        _mergeData.RawData,
+                        entryPos,
+                        payloadLength,
+                        this);
                 }
                 else
                 {
-                    bytesSent = NetManager.SendRawBatchable(_mergeData.RawData, 0, NetConstants.HeaderSize + _mergePos, this);
+                    // Rewrite the two bytes immediately before the payload as a normal Unreliable
+                    // header/channel. This avoids moving the payload for either header length.
+                    int sendOffset = entryPos - NetConstants.UnreliableHeaderSize;
+                    _mergeData.RawData[sendOffset] =
+                        (byte)((byte)PacketProperty.Unreliable | (_connectNum << 5));
+                    _mergeData.RawData[sendOffset + 1] = channel;
+                    bytesSent = NetManager.SendRawBatchable(
+                        _mergeData.RawData,
+                        sendOffset,
+                        NetConstants.UnreliableHeaderSize + payloadLength,
+                        this);
                 }
+
             }
             else
             {
-                //Send without length information and merging
-                bytesSent = NetManager.SendRawBatchable(_mergeData.RawData, NetConstants.HeaderSize + 2, _mergePos - 2, this);
+                // Legacy Merged stores the complete inner packet after a 16-bit length.
+                bytesSent = NetManager.SendRawBatchable(
+                    _mergeData.RawData,
+                    NetConstants.HeaderSize + 2,
+                    _mergePos - 2,
+                    this);
             }
+
 
             // The manager already counts a batched datagram when it flushes; counting here too
             // would double it.
@@ -1593,32 +1681,54 @@ namespace LiteNetLib
         internal void SendUserData(NetPacket packet)
         {
             packet.ConnectionNumber = _connectNum;
+            const int sizeThreshold = 20;
 
-            bool compact = NetManager.CompactMergeEnabled
-                && packet.Property == PacketProperty.Unreliable
-                && !packet.IsFragmented
-                && CompactMerge.CanCarryChannel(packet.RawData[1]);
+            bool isUnreliable = packet.Property == PacketProperty.Unreliable;
+            bool isRawTransport = packet.Property == PacketProperty.Ack || packet.Property == PacketProperty.Channeled;
+            int payloadSize = isUnreliable ? packet.Size - NetConstants.UnreliableHeaderSize : 0;
 
-            int payloadSize = compact ? packet.Size - NetConstants.UnreliableHeaderSize : 0;
-            int entrySize = compact ? CompactMerge.EntrySize(payloadSize) : packet.Size + 2;
-            int mergedPacketSize = NetConstants.HeaderSize + entrySize;
-            const int sizeTreshold = 20;
-            if (mergedPacketSize + sizeTreshold >= _mtu)
+
+            // With compact framing enabled, an out-of-range unreliable channel cannot use the
+            // six-bit channel field. Unreliable traffic is unordered, so bypass the accumulator
+            // without flushing an otherwise useful pending CompactMerged datagram.
+            if (isUnreliable && NetManager.CompactMergeEnabled && !CompactMerge.CanCarryChannel(packet.RawData[1]))
             {
-                //NetDebug.Write(NetLogLevel.Trace, "[P]SendingPacket: " + packet.Property);
                 int bytesSent = NetManager.SendRaw(packet, this);
-
                 if (NetManager.EnableStatistics)
                 {
                     Statistics.IncrementPacketsSent();
                     Statistics.AddBytesSent(bytesSent);
                 }
-
                 return;
             }
+
+            bool compact = NetManager.CompactMergeEnabled &&
+                ((isUnreliable && !packet.IsFragmented) || isRawTransport);
+            int compactPayloadSize = isRawTransport ? packet.Size : payloadSize;
+            int entrySize = compact ? CompactMerge.EntrySize(compactPayloadSize) : packet.Size + 2;
+            int mergedPacketSize = NetConstants.HeaderSize + entrySize;
+
+            if (mergedPacketSize + sizeThreshold >= _mtu)
+            {
+                // Channeled transport has ordering semantics. If an earlier entry is held in the
+                // accumulator, send it before a later Channeled packet that must bypass merging.
+                // Unreliable traffic is unordered and intentionally does not evict the accumulator.
+                if (!isUnreliable && _mergeCount > 0)
+                    SendMerged();
+
+                int bytesSent = NetManager.SendRaw(packet, this);
+                if (NetManager.EnableStatistics)
+                {
+                    Statistics.IncrementPacketsSent();
+                    Statistics.AddBytesSent(bytesSent);
+                }
+                return;
+            }
+
             if (_mergeCount > 0 && compact != _mergeCompact)
                 SendMerged();
-            if (_mergePos + mergedPacketSize > _mtu)
+
+            if (NetConstants.HeaderSize + _mergePos + entrySize > _mtu)
                 SendMerged();
 
             if (_mergeCount == 0)
@@ -1629,22 +1739,43 @@ namespace LiteNetLib
 
             if (compact)
             {
-                _mergePos += CompactMerge.WriteEntry(
-                    _mergeData.RawData,
-                    NetConstants.HeaderSize + _mergePos,
-                    packet.RawData[1],
-                    packet.RawData,
-                    NetConstants.UnreliableHeaderSize,
-                    payloadSize);
+                int entryOffset = NetConstants.HeaderSize + _mergePos;
+                if (isRawTransport)
+                {
+                    _mergePos += CompactMerge.WriteRawEntry(
+                        _mergeData.RawData,
+                        entryOffset,
+                        packet.RawData,
+                        0,
+                        packet.Size);
+                }
+                else
+                {
+                    _mergePos += CompactMerge.WriteUnreliableEntry(
+                        _mergeData.RawData,
+                        entryOffset,
+                        packet.RawData[1],
+                        packet.RawData,
+                        NetConstants.UnreliableHeaderSize,
+                        payloadSize);
+                }
             }
             else
             {
-                FastBitConverter.GetBytes(_mergeData.RawData, _mergePos + NetConstants.HeaderSize, (ushort)packet.Size);
-                Buffer.BlockCopy(packet.RawData, 0, _mergeData.RawData, _mergePos + NetConstants.HeaderSize + 2, packet.Size);
+                FastBitConverter.GetBytes(
+                    _mergeData.RawData,
+                    _mergePos + NetConstants.HeaderSize,
+                    (ushort)packet.Size);
+                Buffer.BlockCopy(
+                    packet.RawData,
+                    0,
+                    _mergeData.RawData,
+                    _mergePos + NetConstants.HeaderSize + 2,
+                    packet.Size);
                 _mergePos += packet.Size + 2;
             }
+
             _mergeCount++;
-            //DebugWriteForce("Merged: " + _mergePos + "/" + (_mtu - 2) + ", count: " + _mergeCount);
         }
 
         internal void Update(float deltaTime)

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkVersion.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkVersion.cs
@@ -4,11 +4,10 @@ namespace Basis.Network.Core
     {
         // 52: restricted-DOF bone encoding — 2-DOF limb/extremity joints and 1-DOF toes ship
         // quantized angles instead of smallest-three quaternions (wire-format change).
-        // 53: hybrid avatar-bundle codec. Byte 0 of the channel-52 bundle header was a message
-        // count that every decoder documented as a hint and none read; it now carries the codec
-        // id and dictionary generation. A v52 client ignores that byte, so it would LZ4-decode a
-        // Zstd bundle into garbage rather than reject it — the version gate is what prevents
-        // that, which is why this is a bump and not a capability negotiation.
-        public static ushort ServerVersion = 53;
+        // 53: hybrid avatar-bundle codec and developer CompactMerged framing. Byte 0 of the
+        // channel-52 bundle header was a message count that every decoder documented as a hint
+        // and none read; it now carries the codec id and dictionary generation.
+        // 54: CompactMerged mixed framing adds raw Ack/Channeled entries (wire-format change).
+        public static ushort ServerVersion = 54;
     }
 }

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/Encryption/BasisCryptoLayer.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/Encryption/BasisCryptoLayer.cs
@@ -15,7 +15,7 @@ namespace Basis.Network.Core
 	/// direction) established by an X25519 handshake; see <see cref="BasisCryptoHandshake"/>.
 	///
 	/// Only the user-data-bearing packet properties are encrypted (Unreliable,
-	/// Channeled, Merged). Connection setup, NAT, MTU and out-of-band probe packets
+	/// Channeled, Merged, CompactMerged). Connection setup, NAT, MTU and out-of-band probe packets
 	/// stay cleartext so the handshake itself never depends on a key being present.
 	///
 	/// Wire layout of an encrypted datagram:
@@ -29,10 +29,11 @@ namespace Basis.Network.Core
 		public const int Overhead = BasisAeadCipher.TagSize + CounterSize;
 
 		private const byte PropertyMask = 0x1F;
-		// Mirrors LiteNetLib.PacketProperty: Unreliable = 0, Channeled = 1, Merged = 12.
+		// Mirrors LiteNetLib.PacketProperty values used for user-data-bearing datagrams.
 		private const byte PropUnreliable = 0;
 		private const byte PropChanneled = 1;
 		private const byte PropMerged = 12;
+		private const byte PropCompactMerged = 18;
 
 		private sealed class Session
 		{
@@ -146,7 +147,8 @@ namespace Basis.Network.Core
 		}
 
 		private static bool IsEncryptable(byte property)
-			=> property == PropUnreliable || property == PropChanneled || property == PropMerged;
+			=> property == PropUnreliable || property == PropChanneled ||
+			   property == PropMerged || property == PropCompactMerged;
 
 		private static void DisposeSession(Session session)
 		{

--- a/Basis/Packages/com.basis.server/LiteNetLib/CompactMerge.cs
+++ b/Basis/Packages/com.basis.server/LiteNetLib/CompactMerge.cs
@@ -6,19 +6,16 @@ namespace LiteNetLib
     /// <summary>
     /// Entry framing for <see cref="PacketProperty.CompactMerged"/> datagrams.
     ///
-    /// <para>Entry layout: <c>[channel | LongLengthFlag][length][payload]</c>, where length is one
-    /// byte, or two when <see cref="LongLengthFlag"/> is set on the channel byte. A
-    /// <see cref="PacketProperty.Merged"/> entry is <c>[ushort size][nested packet]</c> instead,
-    /// and the nested packet carries its own property and channel bytes.</para>
-    ///
-    /// <para>Only plain unreliable messages can be carried: the container property identifies the
-    /// entry type, so the per-entry property byte is dropped, and the channel is limited to
-    /// <see cref="ChannelMask"/> because the top bit selects the length width.</para>
+    /// <para>Bit 7 selects the extended 16-bit length form, bit 6 marks an opaque raw
+    /// Ack/Channeled packet, and bits 0-5 carry the application channel for compact
+    /// unreliable entries. LiteNetLib caps configured application channels at 64, so
+    /// all valid channels fit in six bits.</para>
     /// </summary>
     internal static class CompactMerge
     {
         internal const byte LongLengthFlag = 0x80;
-        internal const byte ChannelMask = 0x7F;
+        internal const byte RawPacketFlag = 0x40;
+        internal const byte ChannelMask = 0x3F;
         internal const int MaxShortLength = byte.MaxValue;
         internal const int ShortEntryOverhead = 2;
         internal const int LongEntryOverhead = 3;
@@ -38,56 +35,139 @@ namespace LiteNetLib
             return channel <= ChannelMask;
         }
 
-        /// <summary>Writes one entry at <paramref name="offset"/> and returns the bytes written.</summary>
-        internal static int WriteEntry(byte[] destination, int offset, byte channel, byte[] source, int sourceOffset, int payloadLength)
+        private static int WriteHeader(byte[] destination, int offset, byte tag, int payloadLength)
         {
-            int start = offset;
             if (payloadLength > MaxShortLength)
             {
-                destination[offset++] = (byte)(channel | LongLengthFlag);
+                destination[offset++] = (byte)(tag | LongLengthFlag);
                 FastBitConverter.GetBytes(destination, offset, (ushort)payloadLength);
-                offset += 2;
+                return LongEntryOverhead;
             }
-            else
-            {
-                destination[offset++] = channel;
-                destination[offset++] = (byte)payloadLength;
-            }
-            Buffer.BlockCopy(source, sourceOffset, destination, offset, payloadLength);
-            return offset + payloadLength - start;
+
+            destination[offset] = tag;
+            destination[offset + 1] = (byte)payloadLength;
+            return ShortEntryOverhead;
+        }
+
+        /// <summary>Writes one compact unreliable entry and returns the bytes written.</summary>
+        internal static int WriteUnreliableEntry(
+            byte[] destination,
+            int offset,
+            byte channel,
+            byte[] source,
+            int sourceOffset,
+            int payloadLength)
+        {
+            int overhead = WriteHeader(destination, offset, channel, payloadLength);
+            Buffer.BlockCopy(source, sourceOffset, destination, offset + overhead, payloadLength);
+            return overhead + payloadLength;
+        }
+
+        // Keep the original helper name for the existing direct codec tests and callers.
+        internal static int WriteEntry(
+            byte[] destination,
+            int offset,
+            byte channel,
+            byte[] source,
+            int sourceOffset,
+            int payloadLength) =>
+            WriteUnreliableEntry(destination, offset, channel, source, sourceOffset, payloadLength);
+
+        /// <summary>Writes one complete raw Ack/Channeled packet and returns the bytes written.</summary>
+        internal static int WriteRawEntry(
+            byte[] destination,
+            int offset,
+            byte[] source,
+            int sourceOffset,
+            int packetLength)
+        {
+            int overhead = WriteHeader(destination, offset, RawPacketFlag, packetLength);
+            Buffer.BlockCopy(source, sourceOffset, destination, offset + overhead, packetLength);
+            return overhead + packetLength;
         }
 
         /// <summary>
         /// Reads the entry header at <paramref name="offset"/>, leaving it on the first payload
-        /// byte. Returns false if the entry is truncated, in which case <paramref name="offset"/>
-        /// is left unusable and the caller must stop parsing.
+        /// byte. Raw entries are accepted only for Ack/Channeled packets, preventing recursive
+        /// CompactMerged nesting and keeping the raw escape canonical.
         /// </summary>
-        internal static bool TryReadEntry(byte[] source, int size, ref int offset, out byte channel, out int payloadLength)
+        internal static bool TryReadEntry(
+            byte[] source,
+            int size,
+            ref int offset,
+            out bool isRawPacket,
+            out byte channel,
+            out int payloadLength)
         {
+            isRawPacket = false;
             channel = 0;
             payloadLength = 0;
-            if (offset >= size)
+
+            if (source == null || size < 0 || size > source.Length || offset < 0 || size - offset < ShortEntryOverhead)
                 return false;
 
             byte tag = source[offset++];
+            isRawPacket = (tag & RawPacketFlag) != 0;
+            channel = (byte)(tag & ChannelMask);
+
+            // Raw entries have no application-channel field. Non-zero low bits would create
+            // alternate encodings of the same packet, so reject them.
+            if (isRawPacket && channel != 0)
+                return false;
+
             if ((tag & LongLengthFlag) != 0)
             {
                 if (size - offset < 2)
                     return false;
                 payloadLength = FastBitConverter.Read<ushort>(source, offset);
                 offset += 2;
+
+                // Keep one canonical encoding: <=255 always uses the short form.
+                if (payloadLength <= MaxShortLength)
+                    return false;
             }
             else
             {
-                if (offset >= size)
-                    return false;
                 payloadLength = source[offset++];
             }
 
-            if (size - offset < payloadLength)
+            if (payloadLength > size - offset)
                 return false;
 
-            channel = (byte)(tag & ChannelMask);
+            if (isRawPacket)
+            {
+                if (payloadLength < NetConstants.ChanneledHeaderSize || payloadLength > NetConstants.MaxPacketSize)
+                    return false;
+
+                PacketProperty property = (PacketProperty)(source[offset] & 0x1F);
+                if (property != PacketProperty.Ack && property != PacketProperty.Channeled)
+                    return false;
+            }
+            else if (payloadLength + NetConstants.UnreliableHeaderSize > NetConstants.MaxPacketSize)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        // Compatibility overload for existing codec tests that only decode unreliable entries.
+        internal static bool TryReadEntry(
+            byte[] source,
+            int size,
+            ref int offset,
+            out byte channel,
+            out int payloadLength)
+        {
+            int originalOffset = offset;
+            if (!TryReadEntry(source, size, ref offset, out bool isRawPacket, out channel, out payloadLength) || isRawPacket)
+            {
+                offset = originalOffset;
+                channel = 0;
+                payloadLength = 0;
+                return false;
+            }
+
             return true;
         }
     }

--- a/Basis/Packages/com.basis.server/LiteNetLib/NetPeer.cs
+++ b/Basis/Packages/com.basis.server/LiteNetLib/NetPeer.cs
@@ -1436,21 +1436,64 @@ namespace LiteNetLib
                     break;
 
                 case PacketProperty.CompactMerged:
-                    int compactPos = NetConstants.HeaderSize;
-                    while (compactPos < packet.Size)
+                    try
                     {
-                        if (!CompactMerge.TryReadEntry(packet.RawData, packet.Size, ref compactPos, out byte compactChannel, out int payloadLength))
-                            break;
+                        int compactPos = NetConstants.HeaderSize;
+                        while (compactPos < packet.Size)
+                        {
+                            if (!CompactMerge.TryReadEntry(
+                                    packet.RawData,
+                                    packet.Size,
+                                    ref compactPos,
+                                    out bool compactRawPacket,
+                                    out byte compactChannel,
+                                    out int payloadLength))
+                            {
+                                break;
+                            }
 
-                        NetPacket unreliable = NetManager.PoolGetPacket(NetConstants.UnreliableHeaderSize + payloadLength);
-                        unreliable.RawData[0] = (byte)PacketProperty.Unreliable;
-                        unreliable.RawData[1] = compactChannel;
-                        Buffer.BlockCopy(packet.RawData, compactPos, unreliable.RawData, NetConstants.UnreliableHeaderSize, payloadLength);
-                        compactPos += payloadLength;
+                            int payloadOffset = compactPos;
+                            compactPos += payloadLength;
 
-                        NetManager.CreateReceiveEvent(unreliable, DeliveryMethod.Unreliable, compactChannel, NetConstants.UnreliableHeaderSize, this);
+                            if (compactRawPacket)
+                            {
+                                NetPacket innerPacket = NetManager.PoolGetPacket(payloadLength);
+                                Buffer.BlockCopy(packet.RawData, payloadOffset, innerPacket.RawData, 0, payloadLength);
+                                innerPacket.Size = payloadLength;
+                                if (!innerPacket.Verify())
+                                {
+                                    NetManager.PoolRecycle(innerPacket);
+                                    break;
+                                }
+
+                                ProcessPacket(innerPacket);
+                                continue;
+                            }
+
+                            NetPacket unreliable = NetManager.PoolGetPacket(NetConstants.UnreliableHeaderSize + payloadLength);
+                            unreliable.RawData[0] = (byte)PacketProperty.Unreliable;
+                            unreliable.ConnectionNumber = _connectNum;
+                            unreliable.RawData[1] = compactChannel;
+                            Buffer.BlockCopy(
+                                packet.RawData,
+                                payloadOffset,
+                                unreliable.RawData,
+                                NetConstants.UnreliableHeaderSize,
+                                payloadLength);
+                            unreliable.Size = NetConstants.UnreliableHeaderSize + payloadLength;
+
+                            NetManager.CreateReceiveEvent(
+                                unreliable,
+                                DeliveryMethod.Unreliable,
+                                compactChannel,
+                                NetConstants.UnreliableHeaderSize,
+                                this);
+                        }
                     }
-                    NetManager.PoolRecycle(packet);
+                    finally
+                    {
+                        NetManager.PoolRecycle(packet);
+                    }
                     break;
 
                 //If we get ping, send pong
@@ -1519,35 +1562,80 @@ namespace LiteNetLib
         {
             if (_mergeCount == 0)
                 return;
+
             int bytesSent;
+
             // Batchable: this is bulk payload traffic and nothing reads the result beyond stats.
             // Outside a batching window this is exactly the old direct send.
             if (_mergeCount > 1)
             {
-                //NetDebug.Write("[P]Send merged: " + _mergePos + ", count: " + _mergeCount);
-                bytesSent = NetManager.SendRawBatchable(_mergeData.RawData, 0, NetConstants.HeaderSize + _mergePos, this);
+                bytesSent = NetManager.SendRawBatchable(
+                    _mergeData.RawData,
+                    0,
+                    NetConstants.HeaderSize + _mergePos,
+                    this);
             }
             else if (_mergeCompact)
             {
-                //Send a lone entry as the unreliable packet it was built from
                 int entryPos = NetConstants.HeaderSize;
-                if (CompactMerge.TryReadEntry(_mergeData.RawData, NetConstants.HeaderSize + _mergePos, ref entryPos, out byte channel, out int payloadLength))
+                if (!CompactMerge.TryReadEntry(
+                        _mergeData.RawData,
+                        NetConstants.HeaderSize + _mergePos,
+                        ref entryPos,
+                        out bool isRawPacket,
+                        out byte channel,
+                        out int payloadLength))
                 {
-                    Buffer.BlockCopy(_mergeData.RawData, entryPos, _mergeData.RawData, NetConstants.UnreliableHeaderSize, payloadLength);
-                    _mergeData.RawData[0] = (byte)((byte)PacketProperty.Unreliable | (_connectNum << 5));
-                    _mergeData.RawData[1] = channel;
-                    bytesSent = NetManager.SendRawBatchable(_mergeData.RawData, 0, NetConstants.UnreliableHeaderSize + payloadLength, this);
+                    byte firstEntryByte0 = _mergePos > 0
+                        ? _mergeData.RawData[NetConstants.HeaderSize]
+                        : (byte)0;
+                    byte firstEntryByte1 = _mergePos > 1
+                        ? _mergeData.RawData[NetConstants.HeaderSize + 1]
+                        : (byte)0;
+                    NetDebug.WriteError(
+                        $"[CompactMerged] Internal single-entry decode failure: count={_mergeCount}, " +
+                        $"pos={_mergePos}, entry0=0x{firstEntryByte0:X2}, entry1=0x{firstEntryByte1:X2}. " +
+                        "Dropping merge buffer.");
+                    _mergePos = 0;
+                    _mergeCount = 0;
+                    _mergeHeldMs = 0f;
+                    return;
+                }
+
+                if (isRawPacket)
+                {
+                    bytesSent = NetManager.SendRawBatchable(
+                        _mergeData.RawData,
+                        entryPos,
+                        payloadLength,
+                        this);
                 }
                 else
                 {
-                    bytesSent = NetManager.SendRawBatchable(_mergeData.RawData, 0, NetConstants.HeaderSize + _mergePos, this);
+                    // Rewrite the two bytes immediately before the payload as a normal Unreliable
+                    // header/channel. This avoids moving the payload for either header length.
+                    int sendOffset = entryPos - NetConstants.UnreliableHeaderSize;
+                    _mergeData.RawData[sendOffset] =
+                        (byte)((byte)PacketProperty.Unreliable | (_connectNum << 5));
+                    _mergeData.RawData[sendOffset + 1] = channel;
+                    bytesSent = NetManager.SendRawBatchable(
+                        _mergeData.RawData,
+                        sendOffset,
+                        NetConstants.UnreliableHeaderSize + payloadLength,
+                        this);
                 }
+
             }
             else
             {
-                //Send without length information and merging
-                bytesSent = NetManager.SendRawBatchable(_mergeData.RawData, NetConstants.HeaderSize + 2, _mergePos - 2, this);
+                // Legacy Merged stores the complete inner packet after a 16-bit length.
+                bytesSent = NetManager.SendRawBatchable(
+                    _mergeData.RawData,
+                    NetConstants.HeaderSize + 2,
+                    _mergePos - 2,
+                    this);
             }
+
 
             // The manager already counts a batched datagram when it flushes; counting here too
             // would double it.
@@ -1593,32 +1681,54 @@ namespace LiteNetLib
         internal void SendUserData(NetPacket packet)
         {
             packet.ConnectionNumber = _connectNum;
+            const int sizeThreshold = 20;
 
-            bool compact = NetManager.CompactMergeEnabled
-                && packet.Property == PacketProperty.Unreliable
-                && !packet.IsFragmented
-                && CompactMerge.CanCarryChannel(packet.RawData[1]);
+            bool isUnreliable = packet.Property == PacketProperty.Unreliable;
+            bool isRawTransport = packet.Property == PacketProperty.Ack || packet.Property == PacketProperty.Channeled;
+            int payloadSize = isUnreliable ? packet.Size - NetConstants.UnreliableHeaderSize : 0;
 
-            int payloadSize = compact ? packet.Size - NetConstants.UnreliableHeaderSize : 0;
-            int entrySize = compact ? CompactMerge.EntrySize(payloadSize) : packet.Size + 2;
-            int mergedPacketSize = NetConstants.HeaderSize + entrySize;
-            const int sizeTreshold = 20;
-            if (mergedPacketSize + sizeTreshold >= _mtu)
+
+            // With compact framing enabled, an out-of-range unreliable channel cannot use the
+            // six-bit channel field. Unreliable traffic is unordered, so bypass the accumulator
+            // without flushing an otherwise useful pending CompactMerged datagram.
+            if (isUnreliable && NetManager.CompactMergeEnabled && !CompactMerge.CanCarryChannel(packet.RawData[1]))
             {
-                //NetDebug.Write(NetLogLevel.Trace, "[P]SendingPacket: " + packet.Property);
                 int bytesSent = NetManager.SendRaw(packet, this);
-
                 if (NetManager.EnableStatistics)
                 {
                     Statistics.IncrementPacketsSent();
                     Statistics.AddBytesSent(bytesSent);
                 }
-
                 return;
             }
+
+            bool compact = NetManager.CompactMergeEnabled &&
+                ((isUnreliable && !packet.IsFragmented) || isRawTransport);
+            int compactPayloadSize = isRawTransport ? packet.Size : payloadSize;
+            int entrySize = compact ? CompactMerge.EntrySize(compactPayloadSize) : packet.Size + 2;
+            int mergedPacketSize = NetConstants.HeaderSize + entrySize;
+
+            if (mergedPacketSize + sizeThreshold >= _mtu)
+            {
+                // Channeled transport has ordering semantics. If an earlier entry is held in the
+                // accumulator, send it before a later Channeled packet that must bypass merging.
+                // Unreliable traffic is unordered and intentionally does not evict the accumulator.
+                if (!isUnreliable && _mergeCount > 0)
+                    SendMerged();
+
+                int bytesSent = NetManager.SendRaw(packet, this);
+                if (NetManager.EnableStatistics)
+                {
+                    Statistics.IncrementPacketsSent();
+                    Statistics.AddBytesSent(bytesSent);
+                }
+                return;
+            }
+
             if (_mergeCount > 0 && compact != _mergeCompact)
                 SendMerged();
-            if (_mergePos + mergedPacketSize > _mtu)
+
+            if (NetConstants.HeaderSize + _mergePos + entrySize > _mtu)
                 SendMerged();
 
             if (_mergeCount == 0)
@@ -1629,22 +1739,43 @@ namespace LiteNetLib
 
             if (compact)
             {
-                _mergePos += CompactMerge.WriteEntry(
-                    _mergeData.RawData,
-                    NetConstants.HeaderSize + _mergePos,
-                    packet.RawData[1],
-                    packet.RawData,
-                    NetConstants.UnreliableHeaderSize,
-                    payloadSize);
+                int entryOffset = NetConstants.HeaderSize + _mergePos;
+                if (isRawTransport)
+                {
+                    _mergePos += CompactMerge.WriteRawEntry(
+                        _mergeData.RawData,
+                        entryOffset,
+                        packet.RawData,
+                        0,
+                        packet.Size);
+                }
+                else
+                {
+                    _mergePos += CompactMerge.WriteUnreliableEntry(
+                        _mergeData.RawData,
+                        entryOffset,
+                        packet.RawData[1],
+                        packet.RawData,
+                        NetConstants.UnreliableHeaderSize,
+                        payloadSize);
+                }
             }
             else
             {
-                FastBitConverter.GetBytes(_mergeData.RawData, _mergePos + NetConstants.HeaderSize, (ushort)packet.Size);
-                Buffer.BlockCopy(packet.RawData, 0, _mergeData.RawData, _mergePos + NetConstants.HeaderSize + 2, packet.Size);
+                FastBitConverter.GetBytes(
+                    _mergeData.RawData,
+                    _mergePos + NetConstants.HeaderSize,
+                    (ushort)packet.Size);
+                Buffer.BlockCopy(
+                    packet.RawData,
+                    0,
+                    _mergeData.RawData,
+                    _mergePos + NetConstants.HeaderSize + 2,
+                    packet.Size);
                 _mergePos += packet.Size + 2;
             }
+
             _mergeCount++;
-            //DebugWriteForce("Merged: " + _mergePos + "/" + (_mtu - 2) + ", count: " + _mergeCount);
         }
 
         internal void Update(float deltaTime)


### PR DESCRIPTION
## Summary
* Merge all UDP Unrealiable into one buffer by passing in a raw packet flag in the bit 7 slot.
* This should prevent buffer flushes when `Ack` or `Channel` packets go through.
* Add `CompactMerged` into `BasisCryptoLayer ` to allow encryption

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [x] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
