### PR TITLE
Fix local BasisOSC publish dispatch

### DIFF
--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Basis.BasisUI;
 using HVR.Basis.Comms.OSC;
+using HVR.Basis.Comms.OSC.Lyuma;
 using HVR.Osushi;
 using Newtonsoft.Json;
 using UnityEngine;
@@ -191,12 +192,15 @@ namespace HVR.Basis.Comms
                 return;
             }
 
+            string typeTag = BuildTypeTag(values);
+            object[] oscArguments = BuildOscArguments(values);
+
             lock (_queryLock)
             {
                 EnsureOscQueryRoot();
                 OsushiNode leaf = EnsureQueryNode(normalizedAddress);
                 leaf.ACCESS = PublishAccess;
-                leaf.TYPE = BuildTypeTag(values);
+                leaf.TYPE = typeTag;
                 leaf.VALUE = BuildQueryValues(values);
             }
 
@@ -204,13 +208,20 @@ namespace HVR.Basis.Comms
             {
                 try
                 {
-                    _client.SendOscMultivalue(normalizedAddress, BuildOscArguments(values));
+                    _client.SendOscMultivalue(normalizedAddress, oscArguments);
                 }
                 catch (Exception e)
                 {
                     BasisDebug.LogWarning($"Failed to publish OSC value ({e.Message})", BasisDebug.LogTag.LocalNetwork);
                 }
             }
+
+            BasisOscService.DispatchToSubscribers(OscMessage.FromRaw(new SimpleOSC.OSCMessage
+            {
+                path = normalizedAddress,
+                typeTag = typeTag,
+                arguments = oscArguments,
+            }));
         }
 
         public void UpdateSubscriptions(EntityId ownerId, IEnumerable<string> subscribedAddresses, IEnumerable<string> subscribedPrefixes)

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
@@ -158,6 +158,15 @@ namespace HVR.Basis.Comms
             }
 
             MessageReceived?.Invoke(message);
+            DispatchToSubscribers(message);
+        }
+
+        internal static void DispatchToSubscribers(OscMessage message)
+        {
+            if (message == null)
+            {
+                return;
+            }
 
             DispatcherState snapshot = Volatile.Read(ref _dispatcherState);
             DeliverMessage(snapshot, message, MatchOwners(snapshot, message.Path ?? string.Empty));

--- a/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs
@@ -625,6 +625,64 @@ namespace HVR.Basis.Comms.Tests
         }
 
         [Test]
+        public void BasisOsc_PublishValue_DispatchesToAnotherLocalSubscriber()
+        {
+            DestroySceneInstance();
+            GameObject avatarObject = new GameObject("OscLocalDispatchAvatar");
+            GameObject publisherObject = new GameObject("OscLocalDispatchPublisher");
+            GameObject subscriberObject = new GameObject("OscLocalDispatchSubscriber");
+            Action<OscMessage> globalHandler = null;
+
+            try
+            {
+                BasisAvatar avatar = avatarObject.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = true;
+                publisherObject.transform.SetParent(avatarObject.transform, false);
+                subscriberObject.transform.SetParent(avatarObject.transform, false);
+
+                BasisOsc publisher = publisherObject.AddComponent<BasisOsc>();
+                BasisOsc subscriber = subscriberObject.AddComponent<BasisOsc>();
+                int callbackCount = 0;
+                int globalCallbackCount = 0;
+                OscMessage receivedMessage = null;
+                OscData[] receivedArguments = null;
+                const string address = "/avatar/public/LocalDispatchProbe";
+
+                subscriber.Subscribe(address, (message, arguments) =>
+                {
+                    callbackCount++;
+                    receivedMessage = message;
+                    receivedArguments = arguments;
+                });
+                globalHandler = _ => globalCallbackCount++;
+                BasisOscService.MessageReceived += globalHandler;
+
+                publisher.PublishValue(address, OscData.Float32(0.75f));
+
+                Assert.That(ResolveNode(GetQueryRoot(), "avatar", "public", "LocalDispatchProbe"), Is.Not.Null,
+                    "PublishValue should still update the OSCQuery node map.");
+                Assert.That(callbackCount, Is.EqualTo(1));
+                Assert.That(globalCallbackCount, Is.EqualTo(0),
+                    "A local publish should not be reflected into inbound/global OSC handlers.");
+                Assert.That(receivedMessage, Is.Not.Null);
+                Assert.That(receivedMessage.Path, Is.EqualTo(address));
+                Assert.That(receivedMessage.TypeTag, Is.EqualTo(",f"));
+                Assert.That(receivedArguments, Has.Length.EqualTo(1));
+                Assert.That(receivedArguments[0].FloatValue, Is.EqualTo(0.75f));
+            }
+            finally
+            {
+                if (globalHandler != null)
+                {
+                    BasisOscService.MessageReceived -= globalHandler;
+                }
+
+                Object.DestroyImmediate(avatarObject);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
         public void BasisOsc_LocalAvatarPublishesIntoAvatarNamespace()
         {
             DestroySceneInstance();


### PR DESCRIPTION
## Summary
* Fixes problem that local `BasisOscSubscriber` couldn't publish a value and trigger another `BasisOscSubscriber` that was listening on the address.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [x] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
