### PR TITLE
Calculate metadata after EditorOnly objects are removed and NDMF runs

### DIFF
--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/AssetBundleBuilder/BasisAssetBundlePipeline.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/AssetBundleBuilder/BasisAssetBundlePipeline.cs
@@ -32,18 +32,18 @@ public static class BasisAssetBundlePipeline
         if (asset != null && asset.GetComponent<BasisAvatar>() != null) return BasisBundleContentKind.Avatar;
         return BasisBundleContentKind.Prop;
     }
-    public static async Task<(bool, (BasisBundleGenerated, AssetBundleBuilder.InformationHash))>
+     public static async Task<(bool, BasisBundleBuild.BasisBundleBuildResult)>
     BuildAssetBundle(GameObject originalPrefab, BasisAssetBundleObject settings, string Password, BuildTarget Target, string buildId)
     {
         return await BuildAssetBundle(false, originalPrefab, new Scene(), settings, Password, Target, buildId);
     }
 
-    public static async Task<(bool, (BasisBundleGenerated, AssetBundleBuilder.InformationHash))>
+    public static async Task<(bool, BasisBundleBuild.BasisBundleBuildResult)>
     BuildAssetBundle(Scene scene, BasisAssetBundleObject settings, string Password, BuildTarget Target, string buildId)
     {
         return await BuildAssetBundle(true, null, scene, settings, Password, Target, buildId);
     }
-    public static async Task<(bool, (BasisBundleGenerated, AssetBundleBuilder.InformationHash))>
+    public static async Task<(bool, BasisBundleBuild.BasisBundleBuildResult)>
   BuildAssetBundle(
       bool isScene,
       GameObject asset,
@@ -71,6 +71,7 @@ public static class BasisAssetBundlePipeline
 
         try
         {
+            BasisBundleConnector.BasisMetaData meta;
             if (isScene)
             {
                 if (settings.RebakeOcclusionCulling)
@@ -86,6 +87,7 @@ public static class BasisAssetBundlePipeline
                 }
 
                 OnBeforeBuildScene?.Invoke(scene, settings);
+                meta = BasisBundleBuild.GenerateSceneMetaData(scene);
                 sceneBuildName = BasisSceneBuildName.Assign(scene);
                 if (sceneBuildName == null)
                 {
@@ -100,6 +102,7 @@ public static class BasisAssetBundlePipeline
                 DestroyEditorOnlyInAvatar(prefab);
                 OnBeforeBuildPrefab?.Invoke(prefab, settings);
                 PostProcessAvatar(prefab);
+                meta = BasisBundleBuild.GenerateMetaData(prefab);
 
                 assetPath = TemporaryStorageHandler.SavePrefabToTemporaryStorage(prefab, settings, ref wasModified, out uniqueID);
 
@@ -143,7 +146,7 @@ public static class BasisAssetBundlePipeline
                 PlayerSettings.SetScriptingBackend(namedBuildTarget, ScriptingImplementation.Mono2x);
             }
 
-            return new(true, value);
+            return new(true, new BasisBundleBuild.BasisBundleBuildResult(value.Item1, value.Item2, meta));
         }
         catch (Exception ex)
         {
@@ -170,7 +173,7 @@ public static class BasisAssetBundlePipeline
                 PlayerSettings.SetScriptingBackend(namedBuildTarget, ScriptingImplementation.Mono2x);
             }
 
-            return new(false, (null, new AssetBundleBuilder.InformationHash()));
+            return new(false, new BasisBundleBuild.BasisBundleBuildResult(null, new AssetBundleBuilder.InformationHash(), default));
         }
         finally
         {

--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisBundleBuild.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisBundleBuild.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Basis.Editor.Localization;
 using Basis.Scripts.BasisSdk;
 using UnityEditor;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.SceneManagement;
@@ -50,11 +51,9 @@ public static class BasisBundleBuild
             }
         }
 
-        var meta = GenerateMetaData(BasisContentBase.gameObject);
         string FolderPath = MakeSafeFolderName(BasisContentBase.BasisBundleDescription.AssetBundleName);
         return await BuildBundle(FolderPath,
             basisContentBase: BasisContentBase,
-            MetaData: meta,
             BasisBounds: BasisBounds,
             Images: Image,
             targets: Targets,
@@ -196,11 +195,9 @@ public static class BasisBundleBuild
         var unitybounds = CalculateSceneBounds(scene);
         BasisBounds BasisBounds = new BasisBounds(unitybounds.center, unitybounds.size);
 
-        var meta = GenerateSceneMetaData(scene);
         string FolderName = MakeSafeFolderName(BasisContentBase.BasisBundleDescription.AssetBundleName);
         return await BuildBundle(FolderName,
             basisContentBase: BasisContentBase,
-            MetaData: meta,
             BasisBounds: BasisBounds,
             Images: Image,
             targets: Targets,
@@ -487,14 +484,13 @@ public static class BasisBundleBuild
     }
     public static async Task<(bool, string)> BuildBundle(string FolderName,
       BasisContentBase basisContentBase,
-      BasisBundleConnector.BasisMetaData MetaData,
       BasisBounds BasisBounds,
       string Images,
       List<BuildTarget> targets,
       bool useProvidedPassword,
       string OverriddenPassword,
       Func<BasisContentBase, BasisAssetBundleObject, string, BuildTarget, string,
-           Task<(bool, (BasisBundleGenerated, AssetBundleBuilder.InformationHash))>> buildFunction,
+           Task<(bool, BasisBundleBuildResult)>> buildFunction,
       string FarLodBase64 = null)
     {
         string generatedID = null;
@@ -550,6 +546,8 @@ public static class BasisBundleBuild
             List<BasisBundleGenerated> bundles = new List<BasisBundleGenerated>(targetsLength + 1);
             List<string> paths = new List<string>();
 
+            bool metaDataSet = false;
+            BasisBundleConnector.BasisMetaData MetaData = default;
             for (int Index = 0; Index < targetsLength; Index++)
             {
                 BuildTarget target = targets[Index];
@@ -561,12 +559,18 @@ public static class BasisBundleBuild
                     return (false, $"Failure While Building for {target}");
                 }
 
-                bundles.Add(result.Item1);
+                if (!metaDataSet)
+                {
+                    MetaData = result.BasisMetaData;
+                    metaDataSet = true;
+                }
 
-                string hashPath = PathConversion(result.Item2.EncyptedPath);
+                bundles.Add(result.BasisBundleGenerated);
+
+                string hashPath = PathConversion(result.InformationHash.EncyptedPath);
                 paths.Add(hashPath);
 
-                BasisDebug.Log("Adding " + result.Item2.EncyptedPath);
+                BasisDebug.Log("Adding " + result.InformationHash.EncyptedPath);
             }
 
             // Avatars additionally get a platform-agnostic Generic (glTF) section, appended
@@ -932,5 +936,19 @@ public static class BasisBundleBuild
         }
         Debug.Log("Hexadecimal string conversion successful.");
         return hex.ToString();
+    }
+
+    public class BasisBundleBuildResult
+    {
+        public BasisBundleBuildResult(BasisBundleGenerated basisBundleGenerated, AssetBundleBuilder.InformationHash informationHash, BasisBundleConnector.BasisMetaData basisMetaData)
+        {
+            BasisBundleGenerated = basisBundleGenerated;
+            InformationHash = informationHash;
+            BasisMetaData = basisMetaData;
+        }
+
+        public BasisBundleGenerated BasisBundleGenerated { get; }
+        public AssetBundleBuilder.InformationHash InformationHash { get; }
+        public BasisBundleConnector.BasisMetaData BasisMetaData { get; }
     }
 }


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? Link related issues. -->

Meta data (avatar statistics) was calculated before EditorOnly objects are removed and before non-destructive tools run. This results in the avatar erroneously having an inflated number of SkinnedMeshRenderer, Material, Triangle, and other counts depending on how many objects were marked as EditorOnly.

This changes the build process so that meta data is calculated after EditorOnly objects are removed and callbacks that modify the prefab run.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [x] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
