### PR TITLE
feat(media): allow Cilbox prop media playback with URL approval

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Basis.BasisUI;
 using UnityEngine;
 using UnityEngine.Rendering;
 
@@ -228,6 +229,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
         set
         {
             if (ReferenceEquals(source, value)) return;
+            ClearPendingUrlApproval();
             // Assigning a CPU frame source takes over from the OS-codec engine.
             TeardownNativeEngine();
             DetachSource();
@@ -527,6 +529,10 @@ public sealed class BasisMediaPlayer : MonoBehaviour
     private Exception pendingError;
     private bool firstFrameEmittedThisPlay;
     private bool audioRateMismatchReported;
+    private bool urlApprovalPending;
+    private bool playRequestedWhileUrlApprovalPending;
+    private string pendingApprovalUrl = string.Empty;
+    private int urlApprovalRequestId;
 
     public long HeadFramePtsUs => videoQueue.TryPeek(out var head) ? head.PresentationTimeUs : -1;
     public long TailFramePtsUs => System.Threading.Interlocked.Read(ref lastEnqueuedPtsUs);
@@ -569,6 +575,110 @@ public sealed class BasisMediaPlayer : MonoBehaviour
         // "www.example.com/…" routes and loads as an absolute URL instead of being
         // mis-read as a direct/transport source.
         url = BasisMediaUrlRouter.NormalizeUrl(url);
+
+        // LoadUrl is always a user-consent boundary, regardless of where the
+        // player lives. Remembered/trusted URLs may pass immediately; every
+        // other URL uses the standard prompt before any resolver/network work.
+        if (!BasisTrustedUrls.IsTrusted(url))
+        {
+            RequestUrlApproval(url);
+            return;
+        }
+
+        LoadApprovedUrl(url);
+    }
+
+    private void RequestUrlApproval(string url)
+    {
+        ClearPendingUrlApproval();
+        if (!BasisMediaPlayerSecurity.IsUrlAllowed(url, out string blockReason))
+        {
+            BasisDebug.LogWarning(
+                $"BasisMediaPlayer refused URL '{BasisMediaUrlRouter.Redact(url)}': {blockReason}",
+                BasisDebug.LogTag.Video);
+            return;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
+        {
+            BasisDebug.LogWarning("BasisMediaPlayer refused invalid URL.", BasisDebug.LogTag.Video);
+            return;
+        }
+
+        pendingApprovalUrl = url;
+        urlApprovalPending = true;
+        int requestId = ++urlApprovalRequestId;
+
+        if (!BasisNotificationCenter.RouteToNotifications)
+        {
+            BasisMainMenu.Open();
+        }
+
+        BasisMenuURLPromptPanel.CreateNew(
+            url,
+            response =>
+            {
+                if (this == null ||
+                    !urlApprovalPending ||
+                    urlApprovalRequestId != requestId ||
+                    !string.Equals(pendingApprovalUrl, url, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                bool playAfterApproval = playRequestedWhileUrlApprovalPending;
+                ClearPendingUrlApproval();
+
+                if (!response.Accepted)
+                {
+                    return;
+                }
+
+                if (response.RememberChoice)
+                {
+                    switch (response.Scope)
+                    {
+                        case BasisMenuURLPromptPanel.RememberChoiceScope.URL:
+                            BasisTrustedUrls.Add(url);
+                            break;
+                        case BasisMenuURLPromptPanel.RememberChoiceScope.Hostname:
+                            BasisTrustedUrls.Add(uri.Scheme + "://" + uri.Host + "/*");
+                            break;
+                        case BasisMenuURLPromptPanel.RememberChoiceScope.Domain:
+                            string[] parts = uri.Host.Split('.');
+                            string domain = parts.Length >= 2
+                                ? parts[parts.Length - 2] + "." + parts[parts.Length - 1]
+                                : uri.Host;
+                            BasisTrustedUrls.Add(uri.Scheme + "://*." + domain + "/*");
+                            break;
+                    }
+                }
+
+                LoadApprovedUrl(url);
+                if (playAfterApproval)
+                {
+                    Play();
+                }
+            },
+            divertible: true);
+    }
+
+    private void ClearPendingUrlApproval()
+    {
+        if (!urlApprovalPending && !playRequestedWhileUrlApprovalPending && string.IsNullOrEmpty(pendingApprovalUrl))
+        {
+            return;
+        }
+
+        urlApprovalPending = false;
+        playRequestedWhileUrlApprovalPending = false;
+        pendingApprovalUrl = string.Empty;
+        urlApprovalRequestId++;
+    }
+
+    private void LoadApprovedUrl(string url)
+    {
+        ClearPendingUrlApproval();
         LastErrorMessage = null;
         LoadGeneration++;
         // Seed URL-derived metadata for the REQUESTED url now, so consumers see
@@ -656,6 +766,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
     // code that assigns Source directly (e.g. BasisSyntheticTestSource for tests).
     public void LoadSource(BasisMediaSource media)
     {
+        ClearPendingUrlApproval();
         if (media == null)
         {
             throw new ArgumentNullException(nameof(media));
@@ -826,6 +937,12 @@ public sealed class BasisMediaPlayer : MonoBehaviour
 
     public void Play()
     {
+        if (urlApprovalPending)
+        {
+            playRequestedWhileUrlApprovalPending = true;
+            return;
+        }
+
         if (nativeEngine != null)
         {
             runtimeIsPaused = false;
@@ -868,6 +985,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
 
     public void Stop()
     {
+        playRequestedWhileUrlApprovalPending = false;
         sleepTimerArmed = false;
         if (nativeEngine != null)
         {
@@ -1069,6 +1187,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
 
     private void OnDestroy()
     {
+        ClearPendingUrlApproval();
         BasisMediaPlayerRegistry.Remove(this);
         subtitleEngine.Clear();
         TeardownNativeEngine();

--- a/Basis/Packages/com.basis.sdk/Scripts/Content Police/ContentPoliceControl.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Content Police/ContentPoliceControl.cs
@@ -20,6 +20,13 @@ public static class ContentPoliceControl
     // Reused renderer buffer for the no-content-removal path when no harvest is
     // supplied. Main-thread only; consumed synchronously by prewarm/correction.
     private static readonly List<Renderer> NoRemovalRendererScratch = new List<Renderer>(64);
+    private const string MediaPlayerStreamingAssemblyQualifiedTypeName = "BasisMediaPlayerStreaming, BasisMediaPlayer";
+    private const string MediaPlayerStreamingTypeName = "BasisMediaPlayerStreaming";
+    private const string MediaPlayerStreamingAutoStartFieldName = "ConfigureOnStart";
+    private static Type mediaPlayerStreamingType;
+    private static FieldInfo mediaPlayerStreamingAutoStartField;
+    private static bool mediaPlayerStreamingPolicyResolved;
+    private static bool mediaPlayerStreamingPolicyInvalidLogged;
 
     // Server-pushed admin lock, mirrored from BasisNetworkModeration.GlobalCilboxLocked by the
     // shim bridge. While set, the avatar content walk strips the Cilbox sandbox host + proxies so
@@ -38,6 +45,65 @@ public static class ContentPoliceControl
     // approved list, so the lookup below can only ever say yes. Skips a FullName + hash probe
     // for one component per GameObject, which on a bone-heavy avatar is most of the walk.
     private static bool IsAlwaysApproved(Component component) => component is Transform;
+
+    private static bool IsAvatarOrPropSelector(BundledContentHolder.Selector selector)
+        => selector == BundledContentHolder.Selector.Avatar || selector == BundledContentHolder.Selector.Prop;
+
+    // BasisSDK intentionally does not reference the media-player assembly. Resolve the optional
+    // runtime type/field lazily and cache them so the normal Content Police walk only pays a Type
+    // reference comparison per component. If the media-player assembly is not loaded yet, leave
+    // the policy unresolved so a later content load can retry.
+    private static bool TryGetMediaPlayerStreamingPolicy(out Type streamingType, out FieldInfo autoStartField)
+    {
+        if (!mediaPlayerStreamingPolicyResolved)
+        {
+            Type resolvedType = Type.GetType(MediaPlayerStreamingAssemblyQualifiedTypeName, throwOnError: false);
+            if (resolvedType != null)
+            {
+                mediaPlayerStreamingType = resolvedType;
+                mediaPlayerStreamingAutoStartField = resolvedType.GetField(
+                    MediaPlayerStreamingAutoStartFieldName,
+                    BindingFlags.Public | BindingFlags.Instance);
+                mediaPlayerStreamingPolicyResolved = true;
+
+                if ((mediaPlayerStreamingAutoStartField == null || mediaPlayerStreamingAutoStartField.FieldType != typeof(bool)) &&
+                    !mediaPlayerStreamingPolicyInvalidLogged)
+                {
+                    mediaPlayerStreamingPolicyInvalidLogged = true;
+                    BasisDebug.LogWarning(
+                        $"[ContentPolice] {MediaPlayerStreamingTypeName} no longer exposes a public bool {MediaPlayerStreamingAutoStartFieldName}; avatar/prop auto-start could not be disabled.",
+                        BasisDebug.LogTag.Event);
+                }
+            }
+        }
+
+        streamingType = mediaPlayerStreamingType;
+        autoStartField = mediaPlayerStreamingAutoStartField;
+        return streamingType != null && autoStartField != null && autoStartField.FieldType == typeof(bool);
+    }
+
+    private static void DisableMediaPlayerStreamingAutoStart(Component component, Type streamingType, FieldInfo autoStartField)
+    {
+        if (component != null && component.GetType() == streamingType)
+        {
+            autoStartField.SetValue(component, false);
+        }
+    }
+
+    private static void DisableMediaPlayerStreamingAutoStart(GameObject root, BundledContentHolder.Selector selector)
+    {
+        if (!IsAvatarOrPropSelector(selector) || root == null ||
+            !TryGetMediaPlayerStreamingPolicy(out Type streamingType, out FieldInfo autoStartField))
+        {
+            return;
+        }
+
+        Component[] streamingComponents = root.GetComponentsInChildren(streamingType, true);
+        for (int i = 0; i < streamingComponents.Length; i++)
+        {
+            autoStartField.SetValue(streamingComponents[i], false);
+        }
+    }
 
     /// <summary>
     /// Creates a copy of a GameObject, removes any unapproved MonoBehaviours, and returns the cleaned copy through instantiation. 
@@ -107,6 +173,11 @@ public static class ContentPoliceControl
             {
                 SearchAndDestroy = GameObject.Instantiate(SearchAndDestroy, Position, Rotation, Parent);
             }
+            // Avatar/prop media streaming must not auto-start from authored data. This path skips
+            // the normal component-removal walk, so apply the content-specific rewrite explicitly
+            // immediately after Instantiate; Unity Start has not run yet.
+            DisableMediaPlayerStreamingAutoStart(SearchAndDestroy, Selector);
+
             // No content-removal walk happened, so a dedicated Renderer-typed walk is the only
             // way to feed the prewarm here. Cheaper than the full component walk above. Only the
             // renderer bucket is filled; the harvest's other buckets stay null so EnsureHarvest
@@ -174,6 +245,10 @@ public static class ContentPoliceControl
                 // is appended only when the caller passed a non-null collector — that way the
                 // data flows back through the call chain rather than living on BasisAvatar.
                 BasisConstraintConversion.Report constraintReport = default;
+                Type streamingType = null;
+                FieldInfo streamingAutoStartField = null;
+                bool sanitizeStreamingAutoStart = IsAvatarOrPropSelector(Selector) &&
+                    TryGetMediaPlayerStreamingPolicy(out streamingType, out streamingAutoStartField);
                 for (int Index = 0; Index < count; Index++)
                 {
                     Component component = components[Index];
@@ -181,6 +256,9 @@ public static class ContentPoliceControl
                     //do this first before we nuke stuff
                     switch (component)
                     {
+                        case Component streaming when sanitizeStreamingAutoStart && streaming.GetType() == streamingType:
+                            DisableMediaPlayerStreamingAutoStart(streaming, streamingType, streamingAutoStartField);
+                            break;
                         case BasisHeadChop headChop:
                             // Authoring-only component: harvest its targets (when a collector
                             // was supplied — local-avatar loads only) and then destroy it so
@@ -409,6 +487,10 @@ public static class ContentPoliceControl
         List<Renderer> renderersForPrewarm = new List<Renderer>();
         List<Component> components = new List<Component>();
         BasisConstraintConversion.Report constraintReport = default;
+        Type streamingType = null;
+        FieldInfo streamingAutoStartField = null;
+        bool sanitizeStreamingAutoStart = IsAvatarOrPropSelector(selector) &&
+            TryGetMediaPlayerStreamingPolicy(out streamingType, out streamingAutoStartField);
         for (int RootIndex = 0; RootIndex < roots.Count; RootIndex++)
         {
             roots[RootIndex].transform.GetComponentsInChildren(includeInactive, components);
@@ -419,6 +501,9 @@ public static class ContentPoliceControl
                 //do this first before we nuke stuff
                 switch (component)
                 {
+                    case Component streaming when sanitizeStreamingAutoStart && streaming.GetType() == streamingType:
+                        DisableMediaPlayerStreamingAutoStart(streaming, streamingType, streamingAutoStartField);
+                        break;
                     case Animator animator:
                         // See the Animator case in the GameObject overload for the
                         // full threat-model comment. AnimationEvents fire via

--- a/Basis/Packages/com.basis.shim/Shims/BasisMediaPlayerShim.cs.meta
+++ b/Basis/Packages/com.basis.shim/Shims/BasisMediaPlayerShim.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0beebfd503f0407ab5d1ad8a6b56c8c1

--- a/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs
+++ b/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using System.Collections.Generic;
 using System;
+using System.Reflection;
 
 namespace Cilbox
 {
@@ -13,6 +14,20 @@ namespace Cilbox
 			"Basis.BasisImageDownloader",
 			"Basis.IBasisImageDownload",
 			"Basis.BasisStringDownloader",
+			// Basis media-player components. BasisMediaPlayer keeps its native API; LoadUrl
+			// enforces URL approval internally, while unsafe lower-level entry points are blocked below.
+			"BasisMediaPlayer",
+			"BasisMediaPlayer+QueueOverflowPolicy",
+			"BasisMediaPlayerStatus",
+			"BasisVideoBufferMode",
+			"BasisMediaPlayerAudio",
+			"BasisMediaPlayerStreaming",
+			"BasisVideoMaterialOutput",
+			"BasisVideoMaterialOutput+MaterialTarget",
+			"BasisVideoProjectionMode",
+			"BasisVideoStereoEye",
+			"BasisVideoAspectMode",
+			"BasisVideoPicture",
 			"Basis.IBasisStringDownload",
             "Basis.Scripts.Networking.NetworkedAvatar.BasisNetworkPlayer",
             "Basis.Scripts.Networking.BasisNetworkPlayers", // Restrictive, see method whitelist (TryGetPlayerByUUID only).
@@ -120,6 +135,17 @@ namespace Cilbox
 			// Read-only local head scale (Vector3) so cloned mirror heads match the local player.
 			"Basis.Scripts.Drivers.BasisLocalAvatarDriver.HeadScale",
 			"Basis.Scripts.Drivers.BasisLocalCameraDriver.CameraInstance",
+			// Media-player configuration is safe to read/write from a prop. Network/file
+			// entry points are methods and are gated separately in CheckMethodAllowed.
+			"BasisMediaPlayer.*",
+			"BasisMediaPlayerAudio.*",
+			// Streaming URLs/platform selection are script-configurable, but ConfigureOnStart
+			// is intentionally withheld so Cilbox cannot re-enable content auto-start.
+			"BasisMediaPlayerStreaming.StreamUrl",
+			"BasisMediaPlayerStreaming.AutoSelectPerPlatform",
+			"BasisMediaPlayerStreaming.PcUrl",
+			"BasisMediaPlayerStreaming.QuestUrl",
+			"BasisVideoMaterialOutput.*",
 		};
 
 		static readonly Dictionary<Type, HashSet<string>> extraMethodWhitelist = new Dictionary<Type, HashSet<string>>()
@@ -287,6 +313,29 @@ namespace Cilbox
 		protected override HashSet<string> ExtraWhiteListType => extraWhiteListType;
 		protected override HashSet<string> ExtraWhiteListFields => extraWhiteListFields;
 		protected override Dictionary<Type, HashSet<string>> ExtraMethodWhitelist => extraMethodWhitelist;
+
+		public override bool CheckMethodAllowed(out MethodInfo mi, Type declaringType, string name,
+			SerializedTypeDescriptor[] parametersIn, SerializedTypeDescriptor[] genericArgumentsIn, string fullSignature)
+		{
+			if (declaringType == typeof(global::BasisMediaPlayer))
+			{
+				// Do not let a prop bypass URL consent through source/file APIs or write
+				// screenshots to disk. Normal playback controls, status, and events remain
+				// available on the real BasisMediaPlayer component.
+				if (name == nameof(global::BasisMediaPlayer.LoadLocalPath) ||
+					name == nameof(global::BasisMediaPlayer.LoadSource) ||
+					name == nameof(global::BasisMediaPlayer.LoadResolvedSource) ||
+					name == nameof(global::BasisMediaPlayer.CaptureScreenshot) ||
+					name == "set_Source" ||
+					name == "set_Renderer")
+				{
+					mi = null;
+					return false;
+				}
+			}
+
+			return base.CheckMethodAllowed(out mi, declaringType, name, parametersIn, genericArgumentsIn, fullSignature);
+		}
 
 		static readonly HashSet<string> mergedWhiteListType = MergeTypes(extraWhiteListType);
 		public static HashSet<string> GetWhiteListTypes() => mergedWhiteListType;


### PR DESCRIPTION
## Summary
* Implement correct URL prompt for any media being played.
* Make sure any content loaded doesn't auto play if not from a scene package.
* Allow only needed calls for Cilbox script to be able to use Basis Media Player.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
