### PR TITLE
Optimize Cilbox interpreter allocations

### DIFF
--- a/Basis/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Basis/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -50,6 +50,10 @@ namespace Cilbox
 
 	public class CilboxMethod
 	{
+		private static readonly ArrayPool<StackElement> stackPool = ArrayPool<StackElement>.Create();
+		[ThreadStatic] private static StackElement[] singleParameterCache;
+		[ThreadStatic] private static bool singleParameterCacheInUse;
+
 		public CilboxClass parentClass;
 		public int MaxStackSize;
 		public String methodName;
@@ -154,40 +158,74 @@ namespace Cilbox
 
 			int plen = parametersIn?.Length ?? 0;
 			int thisOffset = isStatic ? 0 : 1;
+			int parameterCount = plen + thisOffset;
 
-			StackElement [] parameters = new StackElement[plen+thisOffset];
-			StackElement [] stackBuffer = new StackElement[Cilbox.defaultStackSize];
-
-			if( isStatic )
+			bool usingSingleParameterCache = parameterCount == 1 && !singleParameterCacheInUse;
+			StackElement [] parameters;
+			if( parameterCount == 0 )
 			{
-				for( int p = 0; p < plen; p++ )
-					parameters[p].Load( parametersIn[p] );
+				parameters = Array.Empty<StackElement>();
+			}
+			else if( usingSingleParameterCache )
+			{
+				parameters = singleParameterCache ?? (singleParameterCache = new StackElement[1]);
 			}
 			else
 			{
-				parameters[0].Load( ths );
-				for( int p = 0; p < plen; p++ )
-					parameters[p+1].Load( parametersIn[p] );
-				plen++;
+				parameters = new StackElement[parameterCount];
 			}
 
-			object ret = null;
-			if( !parentClass.box.InterpreterEntry(this) ) return null;
+			// This pool is private to Cilbox and every returned buffer is cleared below.
+			// New arrays are zero-initialized, so a rented buffer is always clean without
+			// paying for another full clear on the hot path.
+			StackElement [] stackBuffer = stackPool.Rent(Cilbox.defaultStackSize);
+			if( usingSingleParameterCache ) singleParameterCacheInUse = true;
+
 			try
 			{
-				ret = InterpretInner( stackBuffer, parameters ).AsObject();
-			}
-			catch( Exception e )
-			{
-				parentClass.box.InterpreterExit();
-				if( ths != null ) ths.DisableProxy();
-				else parentClass.box.DisableWithReason(e.ToString());
-				if( e is CilboxUnhandledInterpretedException uhe && uhe.Throwee is System.Exception te ) throw te;
-				throw;
-			}
-			parentClass.box.InterpreterExit();
+				if( isStatic )
+				{
+					for( int p = 0; p < plen; p++ )
+						parameters[p].Load( parametersIn[p] );
+				}
+				else
+				{
+					parameters[0].Load( ths );
+					for( int p = 0; p < plen; p++ )
+						parameters[p+1].Load( parametersIn[p] );
+					plen++;
+				}
 
-			return ret;
+				object ret = null;
+				if( !parentClass.box.InterpreterEntry(this) ) return null;
+				try
+				{
+					ret = InterpretInner( stackBuffer, parameters ).AsObject();
+				}
+				catch( Exception e )
+				{
+					parentClass.box.InterpreterExit();
+					if( ths != null ) ths.DisableProxy();
+					else parentClass.box.DisableWithReason(e.ToString());
+					if( e is CilboxUnhandledInterpretedException uhe && uhe.Throwee is System.Exception te ) throw te;
+					throw;
+				}
+				parentClass.box.InterpreterExit();
+
+				return ret;
+			}
+			finally
+			{
+				if( usingSingleParameterCache )
+				{
+					parameters[0] = default;
+					singleParameterCacheInUse = false;
+				}
+
+				// StackElement contains managed references. Clearing on return both releases
+				// those objects and maintains the private pool's clean-on-rent invariant.
+				stackPool.Return(stackBuffer, clearArray: true);
+			}
 		}
 
 		private StackElement InterpretInner( ArraySegment<StackElement> stackBufferIn, ArraySegment<StackElement> parametersIn )
@@ -445,14 +483,18 @@ spiperf.Begin();
 							object callthis = null;
 							Type[] paTypes = dt.nativeParameterTypes;
 							int numFields = paTypes.Length;
-							object [] callpar = new object[numFields];
-							StackElement [] callpar_se = new StackElement[numFields];
+							object [] callpar = numFields == 0 ? Array.Empty<object>() : new object[numFields];
+							StackElement [] callpar_se = null;
 
 							int ik;
 							for( ik = 0; ik < numFields; ik++ )
 							{
 								StackElement se = stackBuffer[sp--];
-								callpar_se[numFields-ik-1] = se;
+								if( se.type == StackType.Address || se.type == StackType.NativeHandle )
+								{
+									callpar_se ??= new StackElement[numFields];
+									callpar_se[numFields-ik-1] = se;
+								}
 								object o = se.AsObject(box);
 								Type t = paTypes[numFields-ik-1];
 
@@ -599,17 +641,22 @@ spiperf.Begin();
 								}
 							}
 
-							// Possibly copy back any references.
-							for( ik = 0; ik < numFields; ik++ )
+							// Possibly copy back any references. Most native calls have no by-ref
+							// operands, so avoid allocating a parallel StackElement[] unless one
+							// was actually observed while popping arguments.
+							if( callpar_se != null )
 							{
-								StackElement se = callpar_se[ik];
-								if (se.type == StackType.Address)
+								for( ik = 0; ik < numFields; ik++ )
 								{
-									callpar_se[ik].DereferenceLoadAddress( callpar[ik] );
-								}
-								else if ( se.type == StackType.NativeHandle )
-								{
-									callpar_se[ik].DereferenceLoadNativeHandle( box, callpar[ik] );
+									StackElement se = callpar_se[ik];
+									if (se.type == StackType.Address)
+									{
+										callpar_se[ik].DereferenceLoadAddress( callpar[ik] );
+									}
+									else if ( se.type == StackType.NativeHandle )
+									{
+										callpar_se[ik].DereferenceLoadNativeHandle( box, callpar[ik] );
+									}
 								}
 							}
 

--- a/Basis/Packages/com.cnlohr.cilbox/Cilbox.cs
+++ b/Basis/Packages/com.cnlohr.cilbox/Cilbox.cs
@@ -51,8 +51,6 @@ namespace Cilbox
 	public class CilboxMethod
 	{
 		private static readonly ArrayPool<StackElement> stackPool = ArrayPool<StackElement>.Create();
-		[ThreadStatic] private static StackElement[] singleParameterCache;
-		[ThreadStatic] private static bool singleParameterCacheInUse;
 
 		public CilboxClass parentClass;
 		public int MaxStackSize;
@@ -159,40 +157,22 @@ namespace Cilbox
 			int plen = parametersIn?.Length ?? 0;
 			int thisOffset = isStatic ? 0 : 1;
 			int parameterCount = plen + thisOffset;
-
-			bool usingSingleParameterCache = parameterCount == 1 && !singleParameterCacheInUse;
-			StackElement [] parameters;
-			if( parameterCount == 0 )
-			{
-				parameters = Array.Empty<StackElement>();
-			}
-			else if( usingSingleParameterCache )
-			{
-				parameters = singleParameterCache ?? (singleParameterCache = new StackElement[1]);
-			}
-			else
-			{
-				parameters = new StackElement[parameterCount];
-			}
-
-			// This pool is private to Cilbox and every returned buffer is cleared below.
-			// New arrays are zero-initialized, so a rented buffer is always clean without
-			// paying for another full clear on the hot path.
-			StackElement [] stackBuffer = stackPool.Rent(Cilbox.defaultStackSize);
-			if( usingSingleParameterCache ) singleParameterCacheInUse = true;
+			StackElement [] paramStackArray = stackPool.Rent(parameterCount + Cilbox.defaultStackSize);
+			ArraySegment<StackElement> parameters = new (paramStackArray, 0, parameterCount);
+			ArraySegment<StackElement> stackBuffer = new (paramStackArray, parameterCount, Cilbox.defaultStackSize);
 
 			try
 			{
 				if( isStatic )
 				{
 					for( int p = 0; p < plen; p++ )
-						parameters[p].Load( parametersIn[p] );
+						paramStackArray[p].Load( parametersIn[p] );
 				}
 				else
 				{
-					parameters[0].Load( ths );
+					paramStackArray[0].Load( ths );
 					for( int p = 0; p < plen; p++ )
-						parameters[p+1].Load( parametersIn[p] );
+						paramStackArray[p+1].Load( parametersIn[p] );
 					plen++;
 				}
 
@@ -216,15 +196,7 @@ namespace Cilbox
 			}
 			finally
 			{
-				if( usingSingleParameterCache )
-				{
-					parameters[0] = default;
-					singleParameterCacheInUse = false;
-				}
-
-				// StackElement contains managed references. Clearing on return both releases
-				// those objects and maintains the private pool's clean-on-rent invariant.
-				stackPool.Return(stackBuffer, clearArray: true);
+				stackPool.Return(paramStackArray, clearArray: true);
 			}
 		}
 
@@ -483,7 +455,7 @@ spiperf.Begin();
 							object callthis = null;
 							Type[] paTypes = dt.nativeParameterTypes;
 							int numFields = paTypes.Length;
-							object [] callpar = numFields == 0 ? Array.Empty<object>() : new object[numFields];
+							object [] callpar = new object[numFields];
 							StackElement [] callpar_se = null;
 
 							int ik;


### PR DESCRIPTION
## Summary
* Reuse interpreter stack buffers through a private ArrayPool<StackElement>.
* Clear pooled stack buffers when returned so managed references are released safely.
* Avoid parameter-array allocations for zero-argument calls with Array.Empty<StackElement>().
* Reuse a thread-static single-parameter buffer for the common one-argument case.
* Preserve safe behavior for recursive/reentrant execution by falling back to a normal allocation when the cached parameter buffer is already in use.
* Use Array.Empty<object>() for zero-argument native calls.
* Lazily allocate the native-call StackElement[] copyback buffer only when an argument is actually an Address or NativeHandle.
* Skip the copyback loop entirely for normal native calls that cannot modify interpreter values by reference.

### Performance

Measured using 20 simultaneously active Fox Moth avatars running real Cilbox/Vixxy workloads.

| Metric | `origin/developer` | ArrayPool + lazy copyback |
| --- | ---: | ---: |
| Cilbox avg/frame | 1098.364 µs |  641.834 µs |
| Cilbox P50 | 675.846 µs | 532.836 µs |
| Cilbox P95 | 1925.074 µs | 1034.594 µs |
| Per-proxy avg | 54.918 µs | 32.092 µs |
| Per-proxy P95 | 96.254 µs | 51.730 µs |
| GC avg/frame | 505,090 B | 13,244 B |
| GC P95/frame | 522,622 B | 26,302 B |


## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
* Writing jobifiy would required to move the managed memory out of stack element.
